### PR TITLE
Add join function

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export(bin)
 export(closest)
 export(common)
+export(join)
 export(localMaxima)
 export(noise)
 export(ppm)

--- a/R/matching.R
+++ b/R/matching.R
@@ -193,23 +193,23 @@ common <- function(x, table, tolerance = Inf,
 #'
 #' jo <- join(x, y, type = "outer")
 #' jo
-#' x[jo[, "x"]]
-#' y[jo[, "y"]]
+#' x[jo$x]
+#' y[jo$y]
 #'
 #' jl <- join(x, y, type = "left")
 #' jl
-#' x[jl[, "x"]]
-#' y[jl[, "y"]]
+#' x[jl$x]
+#' y[jl$y]
 #'
 #' jr <- join(x, y, type = "right")
 #' jr
-#' x[jr[, "x"]]
-#' y[jr[, "y"]]
+#' x[jr$x]
+#' y[jr$y]
 #'
 #' ji <- join(x, y, type = "inner")
 #' ji
-#' x[ji[, "x"]]
-#' y[ji[, "y"]]
+#' x[ji$x]
+#' y[ji$y]
 join <- function(x, y, tolerance = 0, ppm = 0,
                  type = c("outer", "left", "right", "inner")) {
     switch(match.arg(type),
@@ -221,39 +221,39 @@ join <- function(x, y, tolerance = 0, ppm = 0,
 }
 
 .joinLeft <- function(x, y, tolerance) {
-    cbind(x = seq_along(x),
-          y = closest(x, y, tolerance = tolerance, duplicates = "closest"))
+    list(x = seq_along(x),
+         y = closest(x, y, tolerance = tolerance, duplicates = "closest"))
 }
 
 .joinRight <- function(x, y, tolerance) {
-    cbind(x = closest(y, x, tolerance = tolerance, duplicates = "closest"),
-          y = seq_along(y))
+    list(x = closest(y, x, tolerance = tolerance, duplicates = "closest"),
+         y = seq_along(y))
 }
 
 .joinInner <- function(x, y, tolerance) {
     yi <- closest(y, x, tolerance = tolerance, duplicates = "closest")
     notNa <- which(!is.na(yi))
-    cbind(x = yi[notNa],  y = notNa)
+    list(x = yi[notNa],  y = notNa)
 }
 
 .joinOuter <- function(x, y, tolerance) {
     ji <- .joinInner(x, y, tolerance = tolerance)
     nx <- length(x)
     ny <- length(y)
-    nr <- dim(ji)[1L]
+    nlx <- length(ji[[1L]])
     xy <- xys <- c(x, y)
     ## equalise values that are identified as common
-    if (nr) {
-        xy[nx + ji[, 2L]] <- xy[ji[, 1L]]
-        xys <- xy[-(nx + ji[, 2L])]
+    if (nlx) {
+        xy[nx + ji[[2L]]] <- xy[ji[[1L]]]
+        xys <- xy[-(nx + ji[[2L]])]
     }
     ## find position
     i <- findInterval(xy, sort.int(xys))
     ## fill gaps with NA
-    ox <- oy <- rep.int(NA_integer_, nx + ny - nr)
+    ox <- oy <- rep.int(NA_integer_, nx + ny - nlx)
     sx <- seq_len(nx)
     sy <- seq_len(ny)
     ox[i[sx]] <- sx
     oy[i[nx + sy]] <- sy
-    cbind(x = ox, y = oy)
+    list(x = ox, y = oy)
 }

--- a/R/matching.R
+++ b/R/matching.R
@@ -238,18 +238,18 @@ join <- function(x, y, tolerance = 0, ppm = 0,
 
 .joinOuter <- function(x, y, tolerance) {
     ji <- .joinInner(x, y, tolerance = tolerance)
-    xn <- length(x)
-    yn <- length(y)
+    nx <- length(x)
+    ny <- length(y)
     xy <- c(x, y)
-    ## replace common values
-    xy[xn + ji[, 2L]] <- xy[ji[, 1L]]
+    ## equalise values that are identified as common
+    xy[nx + ji[, 2L]] <- xy[ji[, 1L]]
     ## find position
-    i <- findInterval(xy, sort.int(xy[-(xn + ji[, 2L])]))
+    i <- findInterval(xy, sort.int(xy[-(nx + ji[, 2L])]))
     ## fill gaps with NA
-    ox <- oy <- rep.int(NA_integer_, xn + yn - dim(ji)[1L])
-    sx <- seq_len(xn)
-    sy <- seq_len(yn)
+    ox <- oy <- rep.int(NA_integer_, nx + ny - dim(ji)[1L])
+    sx <- seq_len(nx)
+    sy <- seq_len(ny)
     ox[i[sx]] <- sx
-    oy[i[xn + sy]] <- sy
+    oy[i[nx + sy]] <- sy
     cbind(x = ox, y = oy)
 }

--- a/R/matching.R
+++ b/R/matching.R
@@ -240,13 +240,17 @@ join <- function(x, y, tolerance = 0, ppm = 0,
     ji <- .joinInner(x, y, tolerance = tolerance)
     nx <- length(x)
     ny <- length(y)
-    xy <- c(x, y)
+    nr <- dim(ji)[1L]
+    xy <- xys <- c(x, y)
     ## equalise values that are identified as common
-    xy[nx + ji[, 2L]] <- xy[ji[, 1L]]
+    if (nr) {
+        xy[nx + ji[, 2L]] <- xy[ji[, 1L]]
+        xys <- xy[-(nx + ji[, 2L])]
+    }
     ## find position
-    i <- findInterval(xy, sort.int(xy[-(nx + ji[, 2L])]))
+    i <- findInterval(xy, sort.int(xys))
     ## fill gaps with NA
-    ox <- oy <- rep.int(NA_integer_, nx + ny - dim(ji)[1L])
+    ox <- oy <- rep.int(NA_integer_, nx + ny - nr)
     sx <- seq_len(nx)
     sy <- seq_len(ny)
     ox[i[sx]] <- sx

--- a/man/matching.Rd
+++ b/man/matching.Rd
@@ -143,23 +143,23 @@ y <- c(3, 4, 5, 6, 7)
 
 jo <- join(x, y, type = "outer")
 jo
-x[jo[, "x"]]
-y[jo[, "y"]]
+x[jo$x]
+y[jo$y]
 
 jl <- join(x, y, type = "left")
 jl
-x[jl[, "x"]]
-y[jl[, "y"]]
+x[jl$x]
+y[jl$y]
 
 jr <- join(x, y, type = "right")
 jr
-x[jr[, "x"]]
-y[jr[, "y"]]
+x[jr$x]
+y[jr$y]
 
 ji <- join(x, y, type = "inner")
 ji
-x[ji[, "x"]]
-y[ji[, "y"]]
+x[ji$x]
+y[ji$y]
 }
 \seealso{
 \code{\link[=match]{match()}}

--- a/man/matching.Rd
+++ b/man/matching.Rd
@@ -3,6 +3,7 @@
 \name{closest}
 \alias{closest}
 \alias{common}
+\alias{join}
 \title{Relaxed Value Matching}
 \usage{
 closest(x, table, tolerance = Inf, duplicates = c("keep", "closest",
@@ -10,6 +11,9 @@ closest(x, table, tolerance = Inf, duplicates = c("keep", "closest",
 
 common(x, table, tolerance = Inf, duplicates = c("keep", "closest",
   "remove"))
+
+join(x, y, tolerance = 0, ppm = 0, type = c("outer", "left", "right",
+  "inner"))
 }
 \arguments{
 \item{x}{\code{numeric}, the values to be matched.}
@@ -25,6 +29,14 @@ the same length as \code{table}.}
 \item{nomatch}{\code{numeric(1)}, if the difference
 between the value in \code{x} and \code{table} is larger than
 \code{tolerance} \code{nomatch} is returned.}
+
+\item{y}{\code{numeric}, the values to be joined. Should be sorted.}
+
+\item{ppm}{\code{numeric(1)} representing a relative, value-specific
+parts-per-million (PPM) tolerance that is added to \code{tolerance}.}
+
+\item{type}{\code{character(1)}, defines how \code{x} and \code{y} should be joined. See
+details for \code{join}.}
 }
 \value{
 \code{closest} returns an \code{integer} vector of the same length as \code{x}
@@ -33,6 +45,10 @@ there is no match.
 
 \code{common} returns a \code{logical} vector of length \code{x} that is \code{TRUE} if the
 element in \code{x} was found in \code{table}. It is similar to \code{\link{\%in\%}}.
+
+\code{join} returns a \code{matrix} with two columns, namely \code{x} and \code{y},
+representing the index of the values in \code{x} matching the corresponding value
+in \code{y} (or \code{NA} if the value does not match).
 }
 \description{
 These functions offer relaxed matching of one vector in another.
@@ -41,9 +57,9 @@ just accept \code{numeric} arguments but have an additional \code{tolerance}
 argument that allows relaxed matching.
 }
 \details{
-The \code{tolerance} argument could be set to \code{0} to get the same results as for
-\code{\link[=match]{match()}}. If it is set to \code{Inf} (default) the index of the closest values
-is returned without any restriction.
+For \code{closest}/\code{common} the \code{tolerance} argument could be set to \code{0} to get
+the same results as for \code{\link[=match]{match()}}/\code{\link{\%in\%}}. If it is set to \code{Inf} (default)
+the index of the closest values is returned without any restriction.
 
 It is not guaranteed that there is a one-to-one matching for neither the
 \code{x} to \code{table} nor the \code{table} to \code{x} matching.
@@ -62,10 +78,23 @@ on \code{\link{findInterval}}). If the differences between \code{x} and the corr
 matches in \code{table} are identical the lower index (the smaller element
 in \code{table}) is returned. For \code{duplicates="remove"} all multiple matches
 are returned as \code{nomatch} as above.
+
+\code{join}: joins two \code{numeric} vectors by mapping values in \code{x} with
+values in \code{y} and \emph{vice versa} if they are similar enough (provided the
+\code{tolerance} and \code{ppm} specified). The function returns a \code{matrix} with the
+indices of mapped values in \code{x} and \code{y}. Parameter \code{type} allows to define
+how the vectors will be joined: \code{type = "left"}: values in \code{x} will be
+mapped to values in \code{y}, elements in \code{y} not matching any value in \code{x} will
+be discarded. \code{type = "right"}: same as \code{type = "left"} but for \code{y}.
+\code{type = "outer"}: return matches for all values in \code{x} and in \code{y}.
+\code{type = "inner"}: report only indices of values that could be mapped.
 }
 \note{
-All \code{NA} values in \code{x} are replaced by \code{nomatch} (that is identical to the
-behaviour of \code{match}).
+\code{closest} will replace all \code{NA} values in \code{x} by \code{nomatch} (that is identical
+to the behaviour of \code{match}).
+
+\code{join} is based on \code{closest(x, y, tolerance, duplicates = "closest")}.
+That means for multiple matches just the closest one is reported.
 }
 \examples{
 ## Define two vectors to match
@@ -107,6 +136,30 @@ y <- 1:2
 common(x, y, tolerance = 0.5)
 common(x, y, tolerance = 0.5, duplicates = "closest")
 common(x, y, tolerance = 0.5, duplicates = "remove")
+
+## Join two vectors
+x <- c(1, 2, 3, 6)
+y <- c(3, 4, 5, 6, 7)
+
+jo <- join(x, y, type = "outer")
+jo
+x[jo[, "x"]]
+y[jo[, "y"]]
+
+jl <- join(x, y, type = "left")
+jl
+x[jl[, "x"]]
+y[jl[, "y"]]
+
+jr <- join(x, y, type = "right")
+jr
+x[jr[, "x"]]
+y[jr[, "y"]]
+
+ji <- join(x, y, type = "inner")
+ji
+x[ji[, "x"]]
+y[ji[, "y"]]
 }
 \seealso{
 \code{\link[=match]{match()}}

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -11,6 +11,7 @@ reference:
       - '`bin`'
       - '`closest`'
       - '`common`'
+      - '`join`'
   - title: "Noise/Smoothing"
     desc: "Functions for noise estimation and smoothing."
     contents:

--- a/tests/testthat/test_matching.R
+++ b/tests/testthat/test_matching.R
@@ -70,3 +70,35 @@ test_that("common", {
     expect_equal(common(c(1.6, 1.75, 1.8), 1:2, tolerance = 0.5, duplicates =
                         "remove"), rep(FALSE, 3))
 })
+
+test_that("join", {
+    x <- c(1, 2, 3, 6)
+    y <- c(3, 4, 5, 6, 7)
+
+    expect_equal(join(x, y, type = "outer"),
+                 cbind(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, 1:5)))
+    expect_equal(join(x, y, type = "left"),
+                 cbind(x = 1:4, y = c(NA, NA, 1, 4)))
+    expect_equal(join(x, y, type = "right"),
+                 cbind(x = c(3, NA, NA, 4, NA), y = 1:5))
+    expect_equal(join(x, y, type = "inner"),
+                 cbind(x = 3:4, y = c(1, 4)))
+
+    x <- x + c(-0.1, 0.1)
+    expect_equal(join(x, y, tolerance = 0.1, type = "outer"),
+                 cbind(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, 1:5)))
+    expect_equal(join(x, y, tolerance = 0.1, type = "left"),
+                 cbind(x = 1:4, y = c(NA, NA, 1, 4)))
+    expect_equal(join(x, y, tolerance = 0.1, type = "right"),
+                 cbind(x = c(3, NA, NA, 4, NA), y = 1:5))
+    expect_equal(join(x, y, tolerance = 0.1, type = "inner"),
+                 cbind(x = 3:4, y = c(1, 4)))
+
+    ## multiple matches
+    x <- c(3.95, 4.04)
+    expect_equal(join(x, y, tolerance = 0.1, type = "inner"),
+                 cbind(x = 2, y = 2))
+    x <- c(1, 8)
+    expect_equal(join(x, y, tolerance = 0.1, type = "inner"),
+                 cbind(x = integer(), y = integer()))
+})

--- a/tests/testthat/test_matching.R
+++ b/tests/testthat/test_matching.R
@@ -76,36 +76,35 @@ test_that("join", {
     y <- c(3, 4, 5, 6, 7)
 
     expect_equal(join(x, y, type = "outer"),
-                 cbind(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, 1:5)))
+                 list(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, 1:5)))
     expect_equal(join(x, y, type = "left"),
-                 cbind(x = 1:4, y = c(NA, NA, 1, 4)))
+                 list(x = 1:4, y = c(NA, NA, 1, 4)))
     expect_equal(join(x, y, type = "right"),
-                 cbind(x = c(3, NA, NA, 4, NA), y = 1:5))
+                 list(x = c(3, NA, NA, 4, NA), y = 1:5))
     expect_equal(join(x, y, type = "inner"),
-                 cbind(x = 3:4, y = c(1, 4)))
+                 list(x = 3:4, y = c(1, 4)))
 
     x <- x + c(-0.1, 0.1)
     expect_equal(join(x, y, tolerance = 0.1, type = "outer"),
-                 cbind(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, 1:5)))
+                 list(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, 1:5)))
     expect_equal(join(x, y, tolerance = 0.1, type = "left"),
-                 cbind(x = 1:4, y = c(NA, NA, 1, 4)))
+                 list(x = 1:4, y = c(NA, NA, 1, 4)))
     expect_equal(join(x, y, tolerance = 0.1, type = "right"),
-                 cbind(x = c(3, NA, NA, 4, NA), y = 1:5))
+                 list(x = c(3, NA, NA, 4, NA), y = 1:5))
     expect_equal(join(x, y, tolerance = 0.1, type = "inner"),
-                 cbind(x = 3:4, y = c(1, 4)))
+                 list(x = 3:4, y = c(1, 4)))
 
     ## multiple matches
     x <- c(3.95, 4.04)
     expect_equal(join(x, y, tolerance = 0.1, type = "inner"),
-                 cbind(x = 2, y = 2))
+                 list(x = 2, y = 2))
     x <- c(1, 8)
     expect_equal(join(x, y, tolerance = 0.1, type = "inner"),
-                 cbind(x = integer(), y = integer()))
+                 list(x = integer(), y = integer()))
 
     ## no match at all
     x <- c(1, 2, 3, 6)
     y <- c(4, 5, 7)
     expect_equal(join(x, y, type = "outer"),
-                 cbind(x = c(1:3, NA, NA, 4, NA),
-                       y = c(NA, NA, NA, 1:2, NA, 3)))
+                 list(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, NA, 1:2, NA, 3)))
 })

--- a/tests/testthat/test_matching.R
+++ b/tests/testthat/test_matching.R
@@ -101,4 +101,11 @@ test_that("join", {
     x <- c(1, 8)
     expect_equal(join(x, y, tolerance = 0.1, type = "inner"),
                  cbind(x = integer(), y = integer()))
+
+    ## no match at all
+    x <- c(1, 2, 3, 6)
+    y <- c(4, 5, 7)
+    expect_equal(join(x, y, type = "outer"),
+                 cbind(x = c(1:3, NA, NA, 4, NA),
+                       y = c(NA, NA, NA, 1:2, NA, 3)))
 })


### PR DESCRIPTION
This PR introduces an alternative implementation for the join function
proposed in #10.

The different types of joining were discuessed in
https://github.com/rformassspectrometry/Spectra/issues/46.

There are a few notable differences to #10:
- based on `closest` instead of `groupRun`.
- for multiple matches the **closest** and not the **last** is reported (and
no warning is thrown)
- returns a two-column matrix instead of a list with two elements
- depending on the type of join and the length of `x`/`y` its runtime is
comparable or faster

## Examples and Benchmarks


```r
library("MsCoreUtils")
library("microbenchmark")

## functions copied from the source in R/matching.R in jomaster
groupRun <- function(x, tolerance = 0, ppm = 0) {
    tolerance <- tolerance + sqrt(.Machine$double.eps)
    if (ppm > 0)
        cumsum(c(0L, diff(x) > (tolerance + ppm(x[-length(x)], ppm)))) + 1L
    else
        cumsum(c(0L, diff(x) > tolerance)) + 1L
}

joinNumeric <- function(x, y, tolerance = 0, ppm = 0,
                               join = c("outer", "left", "right", "inner")) {
    join <- match.arg(join)
    vals <- sort(c(x, y))
    ## Multi-matches, will always take the **last**
    grps <- groupRun(vals, tolerance = tolerance, ppm = ppm)
    if (any(rle(grps)$lengths > 2))
        warning("Multiple matches between elements in 'x' and 'y'")
    x_idx <- y_idx <- rep(NA_integer_, grps[length(grps)])
    x_idx[grps[match(x, vals)]] <- seq_along(x)
    y_idx[grps[match(y, vals)]] <- seq_along(y)
    ## WARNING if multiple matches
    keep <- switch(join,
                   "outer" = rep(TRUE, length(x_idx)),
                   "left" = !is.na(x_idx),
                   "right" = !is.na(y_idx),
                   "inner" = !(is.na(y_idx) | is.na(x_idx)))
    list(x = x_idx[keep], y = y_idx[keep])
}

## just for comparision
m2l <- function(x)list(x = x[, 1L], y = x[, 2L])
```

### Simple Test Cases


```r
x <- c(1, 2, 3, 6)
y <- c(3, 4, 5, 6, 7)

all.equal(joinNumeric(x, y, join = "outer"), m2l(join(x, y, type = "outer")))
```

```
## [1] TRUE
```

```r
all.equal(joinNumeric(x, y, join = "left"), m2l(join(x, y, type = "left")))
```

```
## [1] TRUE
```

```r
all.equal(joinNumeric(x, y, join = "right"), m2l(join(x, y, type = "right")))
```

```
## [1] TRUE
```

```r
all.equal(joinNumeric(x, y, join = "inner"), m2l(join(x, y, type = "inner")))
```

```
## [1] TRUE
```

```r
microbenchmark(joinNumeric(x, y, join = "outer"), join(x, y, type = "outer"))
```

```
## Unit: microseconds
##                               expr     min       lq     mean   median
##  joinNumeric(x, y, join = "outer") 108.424 116.5205 172.2582 122.2235
##         join(x, y, type = "outer") 105.953 114.6770 166.4540 127.1455
##        uq     max neval
##  175.2475 675.078   100
##  167.5015 682.189   100
```

```r
microbenchmark(joinNumeric(x, y, join = "left"), join(x, y, type = "left"))
```

```
## Unit: microseconds
##                              expr     min       lq      mean   median
##  joinNumeric(x, y, join = "left") 103.537 108.7685 116.46163 113.6155
##         join(x, y, type = "left")  58.186  62.6030  68.14624  67.5310
##        uq     max neval
##  116.6525 293.789   100
##   72.0360 119.297   100
```

```r
microbenchmark(joinNumeric(x, y, join = "right"), join(x, y, type = "right"))
```

```
## Unit: microseconds
##                               expr     min       lq     mean   median
##  joinNumeric(x, y, join = "right") 105.931 113.0745 174.7425 119.7265
##         join(x, y, type = "right")  56.283  63.3510 100.3886  72.6075
##        uq     max neval
##  168.2765 617.907   100
##  104.9125 383.281   100
```

```r
microbenchmark(joinNumeric(x, y, join = "inner"), join(x, y, type = "inner"))
```

```
## Unit: microseconds
##                               expr     min       lq      mean   median
##  joinNumeric(x, y, join = "inner") 105.099 110.9510 117.18372 114.2510
##         join(x, y, type = "inner")  58.229  63.7405  68.58049  68.7335
##        uq     max neval
##  116.8170 308.663   100
##   72.6415 113.022   100
```

### Multiple matches


```r
y <- c(3, 4, 5, 5.9, 6.2, 7)
## If there are multiple matches, the **last** is reported
joinNumeric(x, y, tolerance = 0.2)
```

```
## Warning in joinNumeric(x, y, tolerance = 0.2): Multiple matches between
## elements in 'x' and 'y'
```

```
## $x
## [1]  1  2  3 NA NA  4 NA
## 
## $y
## [1] NA NA  1  2  3  5  6
```

```r
## If there are multiple matches, the **closest** is reported
join(x, y, tolerance = 0.2)
```

```
##       x  y
## [1,]  1 NA
## [2,]  2 NA
## [3,]  3  1
## [4,] NA  2
## [5,] NA  3
## [6,]  4  4
## [7,] NA  5
## [8,] NA  6
```

### Toy example with "high resolution"


```r
x <- seq(from = 0, to = 5, by = 0.1)
y <- 3:4
joinNumeric(x, y, tolerance = 0.2, join = "inner")
```

```
## Warning in joinNumeric(x, y, tolerance = 0.2, join = "inner"): Multiple
## matches between elements in 'x' and 'y'
```

```
## $x
## [1] 51
## 
## $y
## [1] 2
```

```r
join(x, y, tolerance = 0.2, type = "inner")
```

```
##       x y
## [1,] 31 1
## [2,] 41 2
```

### Real Example


```r
library("MSnbase")
data(itraqdata)

x <- mz(itraqdata[[1]])
y <- mz(itraqdata[[2]])

all.equal(joinNumeric(x, y, ppm = 10, join = "inner"),
          m2l(join(x, y, ppm = 10, type = "inner")))
```

```
## [1] TRUE
```

```r
head(join(x, y, ppm = 10, type = "inner"))
```

```
##       x  y
## [1,]  1  1
## [2,]  2  2
## [3,]  3  3
## [4,]  4  4
## [5,] 59 33
## [6,] 60 34
```

```r
microbenchmark(joinNumeric(x, y, ppm = 10, join = "outer"),
               join(x, y, ppm = 10, type = "outer"))
```

```
## Unit: microseconds
##                                         expr     min       lq     mean
##  joinNumeric(x, y, ppm = 10, join = "outer") 764.817 779.4490 895.3369
##         join(x, y, ppm = 10, type = "outer") 539.631 557.9855 649.8338
##    median       uq      max neval
##  791.5690 828.3265 4216.464   100
##  579.4715 607.1635 3834.321   100
```

```r
microbenchmark(joinNumeric(x, y, ppm = 10, join = "left"),
               join(x, y, ppm = 10, type = "left"))
```

```
## Unit: microseconds
##                                        expr     min       lq     mean
##  joinNumeric(x, y, ppm = 10, join = "left") 764.352 790.4875 887.8073
##         join(x, y, ppm = 10, type = "left") 317.512 336.3725 396.6772
##    median       uq      max neval
##  817.7845 836.4695 4126.528   100
##  351.0325 383.7430 3635.070   100
```

```r
microbenchmark(joinNumeric(x, y, ppm = 10, join = "right"),
               join(x, y, ppm = 10, type = "right"))
```

```
## Unit: microseconds
##                                         expr     min      lq      mean
##  joinNumeric(x, y, ppm = 10, join = "right") 765.755 791.842 1016.4266
##         join(x, y, ppm = 10, type = "right") 258.913 276.302  317.2428
##    median       uq      max neval
##  824.3505 873.8945 5302.678   100
##  287.6585 320.0450  913.624   100
```

```r
microbenchmark(joinNumeric(x, y, ppm = 10, join = "inner"),
               join(x, y, ppm = 10, type = "inner"))
```

```
## Unit: microseconds
##                                         expr     min     lq      mean
##  joinNumeric(x, y, ppm = 10, join = "inner") 768.440 823.20 1141.9637
##         join(x, y, ppm = 10, type = "inner") 267.476 299.41  379.8176
##    median       uq      max neval
##  866.4415 1022.401 7549.351   100
##  317.4745  374.345  932.934   100
```