### PR TITLE
Avoid validity check in assignment after Rle conversion

### DIFF
--- a/R/coerce-rle.R
+++ b/R/coerce-rle.R
@@ -65,9 +65,11 @@ asRleDataFrame <- function(x, columns = character()) {
 #'
 #' @export
 asVectorDataFrame <- function(x) {
-    cols <- colnames(x)[vapply1l(x, is, "Rle")]
-    for (col in cols) {
-        x[[col]] <- as.vector(x[[col]])
-    }
+    slot(x, "listData", check = FALSE) <- lapply(x, function(col) {
+        if (is(col, "Rle"))
+            as.vector(col)
+        else
+            col
+    })
     x
 }


### PR DESCRIPTION
This PR removes one loop and the validity check from `asVectorDataFrame`.

While investigating why `Spectra::compareSpectra` is so slow I found that we spend most of the time in `MsBackendDataFrame::split` (called by `Spectra::as.list` -> `.peaksapply`):

![split](https://user-images.githubusercontent.com/1828443/70502714-dd5dbc80-1b21-11ea-897d-f7f602f1b4cc.png)

Since a few commits there is the following line in `MsBackendDataFrame::split`:
https://github.com/rformassspectrometry/Spectra/blob/7dd0cdeec8a2e86a2c7380b8cab87bd8cf69254f/R/MsBackendDataFrame.R#L532-L534
```r
    if (length(levels(f)) > (nrow(x@spectraData) / 10))
        slot(x, "spectraData", check = FALSE) <-
            asVectorDataFrame(x@spectraData)
```

`if(length(levels(f)) > (nrow(x@spectraData) / 10))` is always `TRUE` if the `nrow(x@spectraData) == 1` (which is the case for `as.list(px)` etc. in `compareSpectra`). So `asVectorDataFrame` is always called. 
Unfortunately `asVectorDataFrame` was horrible slow. Removing one of the loops decreases the run time ~ 10x and avoiding the validation check reduce it by another ~ 20x (so ~ 200x improvement for this test case):

```r
library("MsCoreUtils")
library("Spectra")
fl <- system.file("TripleTOF-SWATH/PestMix1_SWATH.mzML", package = "msdata")
sps <- Spectra(fl, source = MsBackendMzR())
spd <- sps@backend@spectraData

library("microbenchmark")

asVectorDataFrame <- function(x) {
    cols <- colnames(x)[vapply1l(x, is, "Rle")]
    for (col in cols) {
        x[[col]] <- as.vector(x[[col]])
    }
    x
}

asVectorDataFrame2 <- function(x) {
    x[] <- lapply(x, function(col) {
        if (is(col, "Rle"))
            as.vector(col)
        else
            col
    })
    x
}

asVectorDataFrame3 <- function(x) {
    slot(x, "listData", check = FALSE) <- lapply(x, function(col) {
        if (is(col, "Rle"))
            as.vector(col)
        else
            col
    })
    x
}

microbenchmark(
    asVectorDataFrame(spd),
    asVectorDataFrame2(spd),
    asVectorDataFrame3(spd),
    check = "equal"
)
# Unit: milliseconds
#                     expr        min         lq       mean     median         uq
#   asVectorDataFrame(spd) 292.721511 305.226704 314.453273 310.321969 319.181935
#  asVectorDataFrame2(spd)  33.734300  34.861971  36.619442  35.526681  36.636725
#  asVectorDataFrame3(spd)   1.313202   1.413913   1.579972   1.491066   1.580492
#         max neval cld
#  553.790723   100   c
#   55.563240   100  b
#    3.483576   100 a
```
As expected `compareSpectra` improves too:
```r
library("Spectra")
fl <- system.file("TripleTOF-SWATH/PestMix1_SWATH.mzML", package = "msdata")
sps <- Spectra(fl, source = MsBackendMzR())
sps <- sps[1:10]
sps

# unmodified
system.time(compareSpectra(sps[1:5], sps[6:10]))
#    user  system elapsed
#   6.375   0.004   6.385

# MsCoreUtils@asVectorDataFrame
system.time(compareSpectra(sps[1:5], sps[6:10]))
#    user  system elapsed
#   0.293   0.004   0.298
```