### PR TITLE
fix: class(x) != 1; fix #27

### DIFF
--- a/R/rbindFill.R
+++ b/R/rbindFill.R
@@ -34,16 +34,23 @@ rbindFill <- function(...) {
     if (length(l) == 1L)
         l <- l[[1L]]
 
-    cl <- vapply1c(l, class)
+    cnms <- c("matrix", "data.frame", "DataFrame", "DFrame")
+    cls <- vapply(l, inherits, integer(length(cnms)), what = cnms, which = TRUE)
+    rownames(cls) <- cnms
 
-    stopifnot(all(cl %in% c("matrix", "data.frame", "DataFrame", "DFrame")))
+    if (any(!as.logical(colSums(cls))))
+        stop("'rbindFill' just works for ", paste(cls, collapse = ", "))
 
     ## convert matrix to data.frame for easier and equal subsetting and class
     ## determination
-    isMatrix <- cl == "matrix"
+    isMatrix <- as.logical(cls["matrix",])
     l[isMatrix] <- lapply(l[isMatrix], as.data.frame)
 
-    allcl <- unlist(lapply(l, vapply1c, class, USE.NAMES = TRUE))
+    allcl <- unlist(
+        lapply(l, function(ll) {
+            vapply1c(ll, function(lll)class(lll)[1L], USE.NAMES = TRUE)
+        })
+    )
     allnms <- unique(names(allcl))
     allcl <- allcl[allnms]
 

--- a/tests/testthat/test_rbindFill.R
+++ b/tests/testthat/test_rbindFill.R
@@ -1,5 +1,6 @@
 test_that("rbindFill works", {
     require("S4Vectors")
+    expect_error(rbindFill(1:2, 1:4), "just works for")
 
     ## matrix
     a <- matrix(1:9, nrow = 3, ncol = 3)


### PR DESCRIPTION
In recent r-devel `class(x)` could have a `length > 1`, e.g.
`class(matrix)`: `c("matrix", "array")`.