### PR TITLE
Fix `closest` to return `NA` for an empty `table`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MsCoreUtils
 Title: Core Utils for Mass Spectrometry Data
-Version: 1.1.2
+Version: 1.1.3
 Description: MsCoreUtils defines low-level functions for mass
     spectrometry data and is independent of any high-level data
     structures. These functions include mass spectra processing

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # MsCoreUtils 1.1
 
+## Changes in 1.1.3
+
+- For an empty `table` `closest` and `common` return a vector of length `x`
+  with `NA` or `FALSE`, respectively (instead of `1` and `TRUE`).
+  Fixes [#55] <2020-06-18 Thu>.
+
 ## Changes in 1.1.2
 
 - New `colCounts()` aggregation function <2020-05-27 Wed.>
@@ -9,7 +15,7 @@
 - Add some popular distance/similarity metrices:
   `ndotproduct` `neuclidean` `navdist` `nspectraangle`; see also
   [PR #33](https://github.com/rformassspectrometry/MsCoreUtils/pull/33).
-  
+
 - Add deprecation note to `dotproduct` <2020-05-22 Fri>.
 
 ## Changes in 1.1.0

--- a/R/matching.R
+++ b/R/matching.R
@@ -102,6 +102,9 @@ closest <- function(x, table, tolerance = Inf, ppm = 0,
         stop("'nomatch' has to be a 'numeric' of length one.")
 
     ntable <- length(table)
+    if (!ntable)
+        return(rep_len(nomatch, length(x)))
+
     tolerance <- rep_len(tolerance, ntable) + ppm(table, ppm) +
         sqrt(.Machine$double.eps)
     duplicates <- match.arg(duplicates)

--- a/tests/testthat/test_matching.R
+++ b/tests/testthat/test_matching.R
@@ -17,6 +17,10 @@ test_that("closest basically works", {
     expect_equal(closest(c(0.5, 1.5, exp(1), pi), 1:10), c(1, 1, 3, 3))
 })
 
+test_that("closest, length(table) == 0", {
+    expect_equal(closest(1:3, integer()), rep(NA_integer_, 3))
+})
+
 test_that("closest, length(table) == 1, no tolerance", {
     expect_equal(closest(1:3, 0, nomatch = 0, tolerance = 0), c(0, 0, 0))
     expect_equal(closest(1:3, 1, nomatch = 0, tolerance = 0), c(1, 0, 0))
@@ -74,6 +78,8 @@ test_that("common", {
                         "closest"), c(FALSE, TRUE, FALSE))
     expect_equal(common(c(1.6, 1.75, 1.8), 1:2, tolerance = 0.5, duplicates =
                         "remove"), rep(FALSE, 3))
+    # issue 55
+    expect_equal(common(1:3, integer()), rep(FALSE, 3))
 })
 
 test_that("join", {


### PR DESCRIPTION
This PR fixes `closest` (and `common`) for an empty `table` argument.