### PR TITLE
Fix: ignore NA in table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
   with `NA` or `FALSE`, respectively (instead of `1` and `TRUE`).
   Fixes [#55](https://github.com/rformassspectrometry/MsCoreUtils/pull/55)
   <2020-06-18 Thu>.
+- `closest` and `common` ignore `NA` in `table` <2020-06-19>.
 
 ## Changes in 1.1.2
 

--- a/R/matching.R
+++ b/R/matching.R
@@ -101,6 +101,7 @@ closest <- function(x, table, tolerance = Inf, ppm = 0,
     if (!is.numeric(nomatch) || length(nomatch) != 1L)
         stop("'nomatch' has to be a 'numeric' of length one.")
 
+    table <- table[!is.na(table)]
     ntable <- length(table)
     if (!ntable)
         return(rep_len(nomatch, length(x)))

--- a/tests/testthat/test_matching.R
+++ b/tests/testthat/test_matching.R
@@ -17,8 +17,12 @@ test_that("closest basically works", {
     expect_equal(closest(c(0.5, 1.5, exp(1), pi), 1:10), c(1, 1, 3, 3))
 })
 
-test_that("closest, length(table) == 0", {
+test_that("closest, invalid table", {
     expect_equal(closest(1:3, integer()), rep(NA_integer_, 3))
+    expect_equal(closest(1:3, NA), rep(NA_integer_, 3))
+    expect_equal(closest(1:3, c(1, NA)), rep(1, 3))
+    expect_equal(closest(1:3, c(1, NA), tolerance = 0),
+                 c(1, NA_integer_, NA_integer_))
 })
 
 test_that("closest, length(table) == 1, no tolerance", {


### PR DESCRIPTION
This is a follow-up PR to #56 (reported in #55).
It ensures that if `table` is or contains `NA` `closest` return `NA`.
Detected because `common(4, NA)` return `TRUE` before.