### PR TITLE
fix: ensure closest accept just tolerance of length 1 or ntable; closes #61

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,4 +54,4 @@ BugReports: https://github.com/RforMassSpectrometry/MsCoreUtils/issues
 URL: https://github.com/RforMassSpectrometry/MsCoreUtils
 biocViews: Infrastructure, Proteomics, MassSpectrometry, Metabolomics
 Roxygen: list(markdown=TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 ## Changes in 1.1.4
 
 - Change references to `Feature` to `QFeatures` <2020-07-14 Tue>
+- Ensure `closest` accept just argument `tolerance` of length 1 or `length(table)`;
+  see also [#61](https://github.com/rformassspectrometry/MsCoreUtils/issue/61),
+  [PR #62](https://github.com/rformassspectrometry/MsCoreUtils/pull/62)
+  <2020-08-07 Thu>.
 
 ## Changes in 1.1.3
 

--- a/R/matching.R
+++ b/R/matching.R
@@ -106,8 +106,12 @@ closest <- function(x, table, tolerance = Inf, ppm = 0,
     if (!ntable)
         return(rep_len(nomatch, length(x)))
 
-    tolerance <- rep_len(tolerance, ntable) + ppm(table, ppm) +
-        sqrt(.Machine$double.eps)
+    ntolerance <- length(tolerance)
+
+    if (ntolerance != 1L && ntolerance != ntable)
+        stop("'tolerance' hat to be of length 1 or equal to 'length(table)'")
+
+    tolerance <- tolerance + ppm(table, ppm) + sqrt(.Machine$double.eps)
     duplicates <- match.arg(duplicates)
 
     lIdx <- findInterval(x, table, rightmost.closed = FALSE, all.inside = TRUE)

--- a/R/matching.R
+++ b/R/matching.R
@@ -92,10 +92,10 @@ closest <- function(x, table, tolerance = Inf, ppm = 0,
                     duplicates = c("keep", "closest", "remove"),
                     nomatch = NA_integer_) {
 
-    if (!all(is.numeric(tolerance)) || any(tolerance < 0))
+    if (!is.numeric(tolerance) || any(tolerance < 0))
         stop("'tolerance' has to be a 'numeric' larger or equal zero.")
 
-    if(!all(is.numeric(ppm)) || any(ppm < 0))
+    if(!is.numeric(ppm) || any(ppm < 0))
         stop("'ppm' has to be a 'numeric' larger or equal zero.")
 
     if (!is.numeric(nomatch) || length(nomatch) != 1L)

--- a/tests/testthat/test_matching.R
+++ b/tests/testthat/test_matching.R
@@ -3,6 +3,7 @@ test_that("closest throws errors", {
     expect_error(closest(), "missing, with no default")
     expect_error(closest(1:3, 1:3, tolerance = -1), "larger or equal zero")
     expect_error(closest(1:3, 1:3, tolerance = c(1, -1)), "larger or equal zero")
+    expect_error(closest(1:3, 1:3, tolerance = 1:2), "length 1")
     expect_error(closest(1:3, 1:3, ppm = -1), "larger or equal zero")
     expect_warning(closest(1:3, 1:3, ppm = 1:2), "not a multiple of")
     expect_error(closest(1:3, 1.3, tolerance = TRUE), "numeric")


### PR DESCRIPTION
This PR introduces a new `if` statement to catch `tolerance` that arn't 1 or `ntable`.