### PR TITLE
refactor: linear search based closest C implementation

### DIFF
--- a/R/matching.R
+++ b/R/matching.R
@@ -16,7 +16,8 @@
 #' the same length as `x`.
 #' @param ppm `numeric(1)` representing a relative, value-specific
 #'  parts-per-million (PPM) tolerance that is added to `tolerance`.
-#' @param duplicates `character(1)`, how to handle duplicated matches.
+#' @param duplicates `character(1)`, how to handle duplicated matches. Has to be
+#' one of `c("keep", "closest", "remove")`. No abbreviations allowed.
 #' @param nomatch `integer(1)`, if the difference
 #' between the value in `x` and `table` is larger than
 #' `tolerance` `nomatch` is returned.
@@ -131,29 +132,31 @@ closest <- function(x, table, tolerance = Inf, ppm = 0,
 
     tolerance <- tolerance + ppm(x, ppm) + sqrt(.Machine$double.eps)
 
-    duplicates <- match.arg(duplicates)
-
-    if (duplicates == "keep")
+    if (duplicates[1L] == "keep")
         .Call(
             "C_closest_dup_keep",
             as.double(x), as.double(table),
             as.double(tolerance),
             as.integer(nomatch)
         )
-    else if (duplicates == "remove")
-        .Call(
-            "C_closest_dup_remove",
-            as.double(x), as.double(table),
-            as.double(tolerance),
-            as.integer(nomatch)
-        )
-    else if (duplicates == "closest")
+    else if (duplicates[1L] == "closest")
         .Call(
             "C_closest_dup_closest",
             as.double(x), as.double(table),
             as.double(tolerance),
             as.integer(nomatch)
         )
+    else if (duplicates[1L] == "remove")
+        .Call(
+            "C_closest_dup_remove",
+            as.double(x), as.double(table),
+            as.double(tolerance),
+            as.integer(nomatch)
+        )
+    else {
+        stop("'duplicates' has to be one of \"keep\", \"closest\" ",
+             "or \"remove\".")
+    }
 }
 
 #' @rdname matching

--- a/man/matching.Rd
+++ b/man/matching.Rd
@@ -49,7 +49,8 @@ the same length as \code{x}.}
 \item{ppm}{\code{numeric(1)} representing a relative, value-specific
 parts-per-million (PPM) tolerance that is added to \code{tolerance}.}
 
-\item{duplicates}{\code{character(1)}, how to handle duplicated matches.}
+\item{duplicates}{\code{character(1)}, how to handle duplicated matches. Has to be
+one of \code{c("keep", "closest", "remove")}. No abbreviations allowed.}
 
 \item{nomatch}{\code{integer(1)}, if the difference
 between the value in \code{x} and \code{table} is larger than

--- a/man/matching.Rd
+++ b/man/matching.Rd
@@ -99,16 +99,21 @@ for \code{duplicates="remove"} all elements in \code{x} that match to the same e
 in \code{table} are set to \code{nomatch}.
 
 If a single element in \code{x} matches multiple elements in \code{table} the \emph{closest}
-is returned for \code{duplicates="keep"} or \code{duplicates="duplicates"} (\emph{keeping}
+is returned for \code{duplicates="keep"} or \code{duplicates="closest"} (\emph{keeping}
 multiple matches isn't possible in this case because the return value should
 be of the same length as \code{x}). If the differences between \code{x} and the
 corresponding matches in \code{table} are identical the lower index (the smaller
-element in \code{table}) is returned. For \code{duplicates="remove"} all multiple
-matches are returned as \code{nomatch} as above.
+element in \code{table}) is returned. There is one exception: if the lower index
+is already returned for another \code{x} with a smaller difference to this
+\code{index} the higher one is returned for \code{duplicates = "closer"}
+(but only if there is no other \code{x} that is closer to the higher one).
+For \code{duplicates="remove"} all multiple matches are returned as \code{nomatch} as
+above.
 
-\code{.checks = TRUE} tests for increasingly sorted \code{x} and \code{table} arguments that
-are mandatory assumptions for the \code{closest} algorithm. These checks require
-to loop through both vectors and compare each element against its precursor.
+\code{.checks = TRUE} tests among other input validation checks for increasingly
+sorted \code{x} and \code{table} arguments that are mandatory assumptions for the
+\code{closest} algorithm. These checks require to loop through both vectors and
+compare each element against its precursor.
 Depending on the length and distribution of \code{x} and \code{table} these checks take
 equal/more time than the whole \code{closest} algorithm. If it is ensured by other
 methods that both arguments \code{x} and \code{table} are sorted the tests could be

--- a/src/closest.c
+++ b/src/closest.c
@@ -68,13 +68,14 @@ SEXP C_closest_dup_keep(SEXP x, SEXP table, SEXP tolerance, SEXP nomatch) {
  * \return index the closest element
  *
  * \note x and table have to be sorted increasingly and not containing any NA.
+ * \author Sebastian Gibb and Johannes Rainer
  */
 SEXP C_closest_dup_closest(SEXP x, SEXP table, SEXP tolerance, SEXP nomatch) {
     double *px = REAL(x);
     const unsigned int nx = LENGTH(x);
 
     double *ptable = REAL(table);
-    const unsigned int ntable1 = LENGTH(table) - 1;
+    const unsigned int ntable = LENGTH(table);
 
     double *ptolerance = REAL(tolerance);
 
@@ -82,61 +83,45 @@ SEXP C_closest_dup_closest(SEXP x, SEXP table, SEXP tolerance, SEXP nomatch) {
     int* pout = INTEGER(out);
 
     const unsigned int inomatch = asInteger(nomatch);
-    unsigned int j = 1, lastj = 0;
-    double prevdiff = R_PosInf, nextdiff = R_PosInf, lastdiff = R_PosInf;
 
-    for (int i = 0; i < nx; ++i) {
-        while(j < ntable1 && ptable[j] < px[i])
-            ++j;
+    unsigned int ix = 0, ixlastused = 1;
+    unsigned int itbl = 0, itbllastused = 1;
+    double diff = R_PosInf, diffnxtx = R_PosInf, diffnxttbl = R_PosInf;
 
-        /* fabs should be just needed for the first element */
-        prevdiff = fabs(px[i] - ptable[j - 1]);
-        nextdiff = fabs(ptable[j] - px[i]);
+    while (ix < nx) {
+        if (itbl < ntable) {
+            /* difference for current pair */
+            diff = fabs(px[ix] - ptable[itbl]);
+            /* difference for next pairs */
+            diffnxtx =
+                ix + 1 < nx ? fabs(px[ix + 1] - ptable[itbl]) : R_PosInf;
+            diffnxttbl =
+                itbl + 1 < ntable ? fabs(px[ix] - ptable[itbl + 1]) : R_PosInf;
 
-        if (prevdiff <= ptolerance[i] || nextdiff <= ptolerance[i]) {
-            if (prevdiff < nextdiff) {
-                /* match on the left */
-                if (lastj == j) {
-                    if (prevdiff < lastdiff) {
-                        /* same match as before but with smaller difference */
-                        pout[i] = j;
-                        pout[i - 1] = inomatch;
-                        lastdiff = prevdiff;
-                    } else
-                        pout[i] = inomatch;
-                } else {
-                    pout[i] = j;
-                    lastdiff = prevdiff;
-                }
-            } else if (prevdiff > nextdiff) {
-                /* match on the right */
-                if (lastj == j + 1) {
-                    if (nextdiff < lastdiff) {
-                        /* same match as before but with smaller difference */
-                        pout[i] = ++j;
-                        pout[i - 1] = inomatch;
-                        lastdiff = nextdiff;
-                    } else
-                        pout[i] = inomatch;
-                } else {
-                    pout[i] = ++j;
-                    lastdiff = nextdiff;
-                }
+            if (diff <= ptolerance[ix]) {
+                /* valid match, add + 1 to convert between R/C index */
+                pout[ix] = itbl + 1;
+                if (itbl == itbllastused &&
+                        (diffnxtx < diffnxttbl || diff < diffnxttbl))
+                    pout[ixlastused] = inomatch;
+                ixlastused = ix;
+                itbllastused = itbl;
+            } else
+                pout[ix] = inomatch;
+
+            if (diffnxtx < diff || diffnxttbl < diff) {
+                /* increment the index with the smaller distance */
+                if (diffnxtx < diffnxttbl)
+                    ++ix;
+                else
+                    ++itbl;
             } else {
-                /* match on the left or right */
-                if (lastj == j && prevdiff > lastdiff) {
-                    pout[i] = ++j;
-                    lastdiff = nextdiff;
-                } else {
-                    pout[i] = j;
-                    lastdiff = prevdiff;
-                }
+                /* neither next x nor next table item offer a better match */
+                ++ix;
+                ++itbl;
             }
-            lastj = j;
-        } else {
-            pout[i] = inomatch;
-            lastdiff = R_PosInf;
-        }
+        } else
+            pout[ix++] = inomatch;
     }
 
     UNPROTECT(1);

--- a/src/closest.c
+++ b/src/closest.c
@@ -31,6 +31,7 @@ SEXP C_closest_dup_keep(SEXP x, SEXP table, SEXP tolerance, SEXP nomatch) {
     SEXP out = PROTECT(allocVector(INTSXP, nx));
     int* pout = INTEGER(out);
 
+    const unsigned int inomatch = asInteger(nomatch);
     unsigned int j = 1;
 
     double prevdiff = R_PosInf, nextdiff = R_PosInf;
@@ -49,7 +50,7 @@ SEXP C_closest_dup_keep(SEXP x, SEXP table, SEXP tolerance, SEXP nomatch) {
             else
                 pout[i] = ++j;
         } else
-            pout[i] = asInteger(nomatch);
+            pout[i] = inomatch;
     }
 
     UNPROTECT(1);
@@ -80,6 +81,7 @@ SEXP C_closest_dup_closest(SEXP x, SEXP table, SEXP tolerance, SEXP nomatch) {
     SEXP out = PROTECT(allocVector(INTSXP, nx));
     int* pout = INTEGER(out);
 
+    const unsigned int inomatch = asInteger(nomatch);
     unsigned int j = 1, lastj = 0;
     double prevdiff = R_PosInf, nextdiff = R_PosInf, lastdiff = R_PosInf;
 
@@ -98,10 +100,10 @@ SEXP C_closest_dup_closest(SEXP x, SEXP table, SEXP tolerance, SEXP nomatch) {
                     if (prevdiff < lastdiff) {
                         /* same match as before but with smaller difference */
                         pout[i] = j;
-                        pout[i - 1] = asInteger(nomatch);
+                        pout[i - 1] = inomatch;
                         lastdiff = prevdiff;
                     } else
-                        pout[i] = asInteger(nomatch);
+                        pout[i] = inomatch;
                 } else {
                     pout[i] = j;
                     lastdiff = prevdiff;
@@ -112,10 +114,10 @@ SEXP C_closest_dup_closest(SEXP x, SEXP table, SEXP tolerance, SEXP nomatch) {
                     if (nextdiff < lastdiff) {
                         /* same match as before but with smaller difference */
                         pout[i] = ++j;
-                        pout[i - 1] = asInteger(nomatch);
+                        pout[i - 1] = inomatch;
                         lastdiff = nextdiff;
                     } else
-                        pout[i] = asInteger(nomatch);
+                        pout[i] = inomatch;
                 } else {
                     pout[i] = ++j;
                     lastdiff = nextdiff;
@@ -132,7 +134,7 @@ SEXP C_closest_dup_closest(SEXP x, SEXP table, SEXP tolerance, SEXP nomatch) {
             }
             lastj = j;
         } else {
-            pout[i] = asInteger(nomatch);
+            pout[i] = inomatch;
             lastdiff = R_PosInf;
         }
     }
@@ -165,6 +167,7 @@ SEXP C_closest_dup_remove(SEXP x, SEXP table, SEXP tolerance, SEXP nomatch) {
     SEXP out = PROTECT(allocVector(INTSXP, nx));
     int* pout = INTEGER(out);
 
+    const unsigned int inomatch = asInteger(nomatch);
     unsigned int j = 1, lastj = 0;
     double prevdiff = R_PosInf, nextdiff = R_PosInf;
 
@@ -180,22 +183,22 @@ SEXP C_closest_dup_remove(SEXP x, SEXP table, SEXP tolerance, SEXP nomatch) {
             if (prevdiff <= nextdiff) {
                 /* match on the left */
                 if (lastj == j) {
-                    pout[i] = asInteger(nomatch);
-                    pout[i - 1] = asInteger(nomatch);
+                    pout[i] = inomatch;
+                    pout[i - 1] = inomatch;
                 } else {
                     pout[i] = j;
                 }
             } else {
                 /* match on the right */
                 if (lastj == j + 1) {
-                    pout[i] = asInteger(nomatch);
-                    pout[i - 1] = asInteger(nomatch);
+                    pout[i] = inomatch;
+                    pout[i - 1] = inomatch;
                 } else {
                     pout[i] = ++j;
                 }
             }
         } else
-            pout[i] = asInteger(nomatch);
+            pout[i] = inomatch;
         lastj = j;
     }
 

--- a/tests/testthat/test_matching.R
+++ b/tests/testthat/test_matching.R
@@ -80,6 +80,12 @@ test_that("closest, duplicates", {
     y <- as.numeric(c(3, 4, 5, 7))
     expect_equal(closest(x, y, tolerance = 1, duplicates = "closest"),
                  c(NA, 1, 3, 4, NA))
+    # multiple match, with better match following, see
+    # https://github.com/rformassspectrometry/MsCoreUtils/issues/66
+    x <- c(1, 1.5, 2, 2.1, 5, 6, 7)
+    y <- c(4.6, 4.7, 4.8, 4.9, 5, 6, 7, 8)
+    expect_equal(closest(x, y, tolerance = 3, duplicates = "closest"),
+                 c(NA, NA, NA, 1, 5, 6, 7))
 })
 
 test_that("common", {

--- a/tests/testthat/test_matching.R
+++ b/tests/testthat/test_matching.R
@@ -72,6 +72,13 @@ test_that("closest, duplicates", {
     expect_equal(closest(1.6, 1:2, tolerance = 0.5, duplicates = "keep"), 2)
     expect_equal(closest(1.6, 1:2, tolerance = 0.5, duplicates = "closest"), 2)
     expect_equal(closest(1.5, 1:2, tolerance = 0.5, duplicates = "remove"), 1)
+
+    # equal distances, see
+    # https://github.com/rformassspectrometry/MsCoreUtils/issues/65
+    x <- as.numeric(c(1, 3, 5, 6, 8))
+    y <- as.numeric(c(3, 4, 5, 7))
+    expect_equal(closest(x, y, tolerance = 1, duplicates = "closest"),
+                 c(NA, 1, 3, 4, NA))
 })
 
 test_that("common", {

--- a/tests/testthat/test_matching.R
+++ b/tests/testthat/test_matching.R
@@ -11,7 +11,8 @@ test_that("closest throws errors", {
     expect_error(closest(1:3, 1:3, nomatch = TRUE), "be a 'numeric'")
     expect_error(closest(1, 1, nomatch = 1:2),
                  "'nomatch' has to be a 'numeric' of length one")
-    expect_error(closest(1:3, c(1, NA)), "not  contain NA")
+    expect_error(closest(1:3, c(1, NA)), "not contain NA")
+    expect_error(closest(1:3, 1:3, duplicates = "foo"), "has to be .*keep.*,")
 })
 
 test_that("closest basically works", {


### PR DESCRIPTION
This PR is a rewrite of the `closest` C implementation. Instead of the original binary it uses a linear search which is faster in our use cases (relatively small number of possible matches (< 1e7) and both arrays are sorted). Additionally it includes more validation checks in `if (.check)`. The implementation of `C_closest_dup_closest` is heavily inspired by @jorainer implementation of the left join in #63 .

This PR closes #65 and #66 for `closest` (however, we will replace the R implementation of the join* functions anyway).

BTW: the build on travis is failing with
```
--- re-building ‘MsCoreUtils.Rmd’ using rmarkdown
Quitting from lines 17-18 (MsCoreUtils.Rmd) 
Error: processing vignette 'MsCoreUtils.Rmd' failed with diagnostics:
argument is of length zero
--- failed re-building ‘MsCoreUtils.Rmd’
```
https://github.com/rformassspectrometry/MsCoreUtils/blob/eeec49f60bfc36e5dc7498c9efc34d98300ac2d2/vignettes/MsCoreUtils.Rmd#L17

I can't reproduce this locally. Any ideas?