### PR TITLE
Follow up to PR #63 Implementing peak joining in C 2nd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MsCoreUtils
 Title: Core Utils for Mass Spectrometry Data
-Version: 1.1.6
+Version: 1.1.7
 Description: MsCoreUtils defines low-level functions for mass
     spectrometry data and is independent of any high-level data
     structures. These functions include mass spectra processing

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # MsCoreUtils 1.1
 
+## Changes in 1.1.7
+
+- Rewrite `c("left", "right", "inner", "outer")` `join` in C <2020-10-06 Tue>.
+
 ## Changes in 1.1.6
 
 - Rewrite `closest` in C <2020-09-24 Thu>.

--- a/R/matching.R
+++ b/R/matching.R
@@ -70,7 +70,7 @@
 #' there is no match.
 #'
 #' @rdname matching
-#' @author Sebastian Gibb
+#' @author Sebastian Gibb, Johannes Rainer
 #' @seealso [`match()`]
 #' @aliases closest
 #' @family grouping/matching functions
@@ -244,17 +244,17 @@ join <- function(x, y, tolerance = 0, ppm = 0,
                  type = c("outer", "left", "right", "inner"), .check = TRUE,
                  ...) {
     switch(match.arg(type),
-           "outer" = .joinOuter(
-                x, y, tolerance = tolerance, ppm = ppm, .check = .check
+           "outer" = .cjoinOuter(
+               x, y, tolerance = tolerance, ppm = ppm, .check = .check
            ),
-           "left" = .joinLeft(
-                x, y, tolerance = tolerance, ppm = ppm, .check = .check
+           "left" = .cjoinLeft(
+               x, y, tolerance = tolerance, ppm = ppm, .check = .check
            ),
            "right" = .joinRight(
-                x, y, tolerance = tolerance, ppm = ppm, .check = .check
+               x, y, tolerance = tolerance, ppm = ppm, .check = .check
            ),
            "inner" = .joinInner(
-                x, y, tolerance = tolerance, ppm = ppm, .check = .check
+               x, y, tolerance = tolerance, ppm = ppm, .check = .check
            )
     )
 }
@@ -298,4 +298,36 @@ join <- function(x, y, tolerance = 0, ppm = 0,
     ox[i[sx]] <- sx
     oy[i[nx + sy]] <- sy
     list(x = ox, y = oy)
+}
+
+.cjoinOuter <- function(x = numeric(), y = numeric(), tolerance = 0, ppm = 0,
+                        .check = TRUE) {
+    tolerance <- tolerance + ppm(x, ppm = ppm) + sqrt(.Machine$double.eps)
+    if (is.integer(x))
+        x <- as.numeric(x)
+    if (is.integer(y))
+        y <- as.numeric(y)
+    if (.check && (
+            !identical(FALSE, is.unsorted(x)) ||
+            !identical(FALSE, is.unsorted(y)))) {
+        stop("'x' and 'y' have to be sorted non-decreasingly and must not ",
+             " contain NA.")
+    }
+    .Call("C_join_outer", x, y, tolerance)
+}
+
+.cjoinLeft <- function(x = numeric(), y = numeric(), tolerance = 0, ppm = 0,
+                       .check = TRUE) {
+    tolerance <- tolerance + ppm(x, ppm = ppm) + sqrt(.Machine$double.eps)
+    if (is.integer(x))
+        x <- as.numeric(x)
+    if (is.integer(y))
+        y <- as.numeric(y)
+    if (.check && (
+            !identical(FALSE, is.unsorted(x)) ||
+            !identical(FALSE, is.unsorted(y)))) {
+        stop("'x' and 'y' have to be sorted non-decreasingly and must not ",
+             " contain NA.")
+    }
+    .Call("C_join_left", x, y, tolerance)
 }

--- a/R/matching.R
+++ b/R/matching.R
@@ -333,3 +333,51 @@ join <- function(x, y, tolerance = 0, ppm = 0,
     }
     .Call("C_join_left", x, y, tolerance)
 }
+
+.cjoinLeft2 <- function(x = numeric(), y = numeric(), tolerance = 0, ppm = 0,
+                       .check = TRUE) {
+    tolerance <- tolerance + ppm(x, ppm = ppm) + sqrt(.Machine$double.eps)
+    if (is.integer(x))
+        x <- as.numeric(x)
+    if (is.integer(y))
+        y <- as.numeric(y)
+    if (.check && (
+            !identical(FALSE, is.unsorted(x)) ||
+            !identical(FALSE, is.unsorted(y)))) {
+        stop("'x' and 'y' have to be sorted non-decreasingly and must not ",
+             " contain NA.")
+    }
+    .Call("C_join_left2", x, y, tolerance, NA_integer_)
+}
+
+.cjoinInner2 <- function(x = numeric(), y = numeric(), tolerance = 0, ppm = 0,
+                       .check = TRUE) {
+    tolerance <- tolerance + ppm(x, ppm = ppm) + sqrt(.Machine$double.eps)
+    if (is.integer(x))
+        x <- as.numeric(x)
+    if (is.integer(y))
+        y <- as.numeric(y)
+    if (.check && (
+            !identical(FALSE, is.unsorted(x)) ||
+            !identical(FALSE, is.unsorted(y)))) {
+        stop("'x' and 'y' have to be sorted non-decreasingly and must not ",
+             " contain NA.")
+    }
+    .Call("C_join_inner2", x, y, tolerance, NA_integer_)
+}
+
+.cjoinOuter2 <- function(x = numeric(), y = numeric(), tolerance = 0, ppm = 0,
+                       .check = TRUE) {
+    tolerance <- tolerance + ppm(x, ppm = ppm) + sqrt(.Machine$double.eps)
+    if (is.integer(x))
+        x <- as.numeric(x)
+    if (is.integer(y))
+        y <- as.numeric(y)
+    if (.check && (
+            !identical(FALSE, is.unsorted(x)) ||
+            !identical(FALSE, is.unsorted(y)))) {
+        stop("'x' and 'y' have to be sorted non-decreasingly and must not ",
+             " contain NA.")
+    }
+    .Call("C_join_outer2", x, y, tolerance, NA_integer_)
+}

--- a/R/matching.R
+++ b/R/matching.R
@@ -243,7 +243,7 @@ common <- function(x, table, tolerance = Inf, ppm = 0,
 join <- function(x, y, tolerance = 0, ppm = 0,
                  type = c("outer", "left", "right", "inner"), .check = TRUE,
                  ...) {
-    switch(match.arg(type),
+    switch(type,
            "outer" = .cjoinOuter(
                x, y, tolerance = tolerance, ppm = ppm, .check = .check
            ),
@@ -255,7 +255,9 @@ join <- function(x, y, tolerance = 0, ppm = 0,
            ),
            "inner" = .joinInner(
                x, y, tolerance = tolerance, ppm = ppm, .check = .check
-           )
+           ),
+           stop("'type' has to be one of \"outer\", \"left\", \"right\", or ",
+                "\"inner\"")
     )
 }
 

--- a/R/matching.R
+++ b/R/matching.R
@@ -138,31 +138,28 @@ closest <- function(x, table, tolerance = Inf, ppm = 0,
 
     tolerance <- tolerance + ppm(x, ppm) + sqrt(.Machine$double.eps)
 
-    if (duplicates[1L] == "keep")
-        .Call(
+    switch(duplicates[1L],
+        "keep" = .Call(
             "C_closest_dup_keep",
             as.double(x), as.double(table),
             as.double(tolerance),
             as.integer(nomatch)
-        )
-    else if (duplicates[1L] == "closest")
-        .Call(
+        ),
+        "closest" = .Call(
             "C_closest_dup_closest",
             as.double(x), as.double(table),
             as.double(tolerance),
             as.integer(nomatch)
-        )
-    else if (duplicates[1L] == "remove")
-        .Call(
+        ),
+        "remove" = .Call(
             "C_closest_dup_remove",
             as.double(x), as.double(table),
             as.double(tolerance),
             as.integer(nomatch)
-        )
-    else {
+        ),
         stop("'duplicates' has to be one of \"keep\", \"closest\" ",
              "or \"remove\".")
-    }
+    )
 }
 
 #' @rdname matching
@@ -257,7 +254,7 @@ join <- function(x, y, tolerance = 0, ppm = 0,
 
     tolerance <- tolerance + ppm(x, ppm = ppm) + sqrt(.Machine$double.eps)
 
-    switch(type,
+    switch(type[1L],
            "outer" = .Call("C_join_outer", x, y, tolerance, NA_integer_),
            "left" = .Call("C_join_left", x, y, tolerance, NA_integer_),
            "right" = .Call("C_join_right", x, y, tolerance, NA_integer_),

--- a/man/matching.Rd
+++ b/man/matching.Rd
@@ -213,6 +213,6 @@ Other grouping/matching functions:
 \code{\link{bin}()}
 }
 \author{
-Sebastian Gibb
+Sebastian Gibb, Johannes Rainer
 }
 \concept{grouping/matching functions}

--- a/src/MsCoreUtils.h
+++ b/src/MsCoreUtils.h
@@ -13,7 +13,10 @@ extern SEXP C_closest_dup_remove(SEXP, SEXP, SEXP, SEXP);
 extern SEXP C_impNeighbourAvg(SEXP, SEXP);
 
 extern SEXP C_join_left(SEXP, SEXP, SEXP);
+extern SEXP C_join_left2(SEXP, SEXP, SEXP, SEXP);
+extern SEXP C_join_inner2(SEXP, SEXP, SEXP, SEXP);
 extern SEXP C_join_outer(SEXP, SEXP, SEXP);
+extern SEXP C_join_outer2(SEXP, SEXP, SEXP, SEXP);
 
 extern SEXP C_localMaxima(SEXP, SEXP);
 

--- a/src/MsCoreUtils.h
+++ b/src/MsCoreUtils.h
@@ -12,6 +12,9 @@ extern SEXP C_closest_dup_remove(SEXP, SEXP, SEXP, SEXP);
 
 extern SEXP C_impNeighbourAvg(SEXP, SEXP);
 
+extern SEXP C_join_left(SEXP, SEXP, SEXP);
+extern SEXP C_join_outer(SEXP, SEXP, SEXP);
+
 extern SEXP C_localMaxima(SEXP, SEXP);
 
 extern SEXP _MsCoreUtils_imp_neighbour_avg(SEXP, SEXP);

--- a/src/MsCoreUtils.h
+++ b/src/MsCoreUtils.h
@@ -13,6 +13,7 @@ extern SEXP C_closest_dup_remove(SEXP, SEXP, SEXP, SEXP);
 extern SEXP C_impNeighbourAvg(SEXP, SEXP);
 
 extern SEXP C_join_left(SEXP, SEXP, SEXP, SEXP);
+extern SEXP C_join_right(SEXP, SEXP, SEXP, SEXP);
 extern SEXP C_join_inner(SEXP, SEXP, SEXP, SEXP);
 extern SEXP C_join_outer(SEXP, SEXP, SEXP, SEXP);
 

--- a/src/MsCoreUtils.h
+++ b/src/MsCoreUtils.h
@@ -12,11 +12,9 @@ extern SEXP C_closest_dup_remove(SEXP, SEXP, SEXP, SEXP);
 
 extern SEXP C_impNeighbourAvg(SEXP, SEXP);
 
-extern SEXP C_join_left(SEXP, SEXP, SEXP);
-extern SEXP C_join_left2(SEXP, SEXP, SEXP, SEXP);
-extern SEXP C_join_inner2(SEXP, SEXP, SEXP, SEXP);
-extern SEXP C_join_outer(SEXP, SEXP, SEXP);
-extern SEXP C_join_outer2(SEXP, SEXP, SEXP, SEXP);
+extern SEXP C_join_left(SEXP, SEXP, SEXP, SEXP);
+extern SEXP C_join_inner(SEXP, SEXP, SEXP, SEXP);
+extern SEXP C_join_outer(SEXP, SEXP, SEXP, SEXP);
 
 extern SEXP C_localMaxima(SEXP, SEXP);
 

--- a/src/init.c
+++ b/src/init.c
@@ -5,11 +5,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_closest_dup_closest", (DL_FUNC) &C_closest_dup_closest, 4},
     {"C_closest_dup_remove", (DL_FUNC) &C_closest_dup_remove, 4},
     {"C_impNeighbourAvg", (DL_FUNC) &C_impNeighbourAvg, 2},
-    {"C_join_outer", (DL_FUNC) &C_join_outer, 3},
-    {"C_join_outer2", (DL_FUNC) &C_join_outer2, 4},
-    {"C_join_left", (DL_FUNC) &C_join_left, 3},
-    {"C_join_left2", (DL_FUNC) &C_join_left2, 4},
-    {"C_join_inner2", (DL_FUNC) &C_join_inner2, 4},
+    {"C_join_outer", (DL_FUNC) &C_join_outer, 4},
+    {"C_join_left", (DL_FUNC) &C_join_left, 4},
+    {"C_join_inner", (DL_FUNC) &C_join_inner, 4},
     {"C_localMaxima", (DL_FUNC) &C_localMaxima, 2},
     {NULL, NULL, 0}
 };

--- a/src/init.c
+++ b/src/init.c
@@ -5,6 +5,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_closest_dup_closest", (DL_FUNC) &C_closest_dup_closest, 4},
     {"C_closest_dup_remove", (DL_FUNC) &C_closest_dup_remove, 4},
     {"C_impNeighbourAvg", (DL_FUNC) &C_impNeighbourAvg, 2},
+    {"C_join_outer", (DL_FUNC) &C_join_outer, 3},
+    {"C_join_left", (DL_FUNC) &C_join_left, 3},
     {"C_localMaxima", (DL_FUNC) &C_localMaxima, 2},
     {NULL, NULL, 0}
 };

--- a/src/init.c
+++ b/src/init.c
@@ -5,9 +5,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_closest_dup_closest", (DL_FUNC) &C_closest_dup_closest, 4},
     {"C_closest_dup_remove", (DL_FUNC) &C_closest_dup_remove, 4},
     {"C_impNeighbourAvg", (DL_FUNC) &C_impNeighbourAvg, 2},
-    {"C_join_outer", (DL_FUNC) &C_join_outer, 4},
     {"C_join_left", (DL_FUNC) &C_join_left, 4},
+    {"C_join_right", (DL_FUNC) &C_join_right, 4},
     {"C_join_inner", (DL_FUNC) &C_join_inner, 4},
+    {"C_join_outer", (DL_FUNC) &C_join_outer, 4},
     {"C_localMaxima", (DL_FUNC) &C_localMaxima, 2},
     {NULL, NULL, 0}
 };

--- a/src/init.c
+++ b/src/init.c
@@ -6,7 +6,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_closest_dup_remove", (DL_FUNC) &C_closest_dup_remove, 4},
     {"C_impNeighbourAvg", (DL_FUNC) &C_impNeighbourAvg, 2},
     {"C_join_outer", (DL_FUNC) &C_join_outer, 3},
+    {"C_join_outer2", (DL_FUNC) &C_join_outer2, 4},
     {"C_join_left", (DL_FUNC) &C_join_left, 3},
+    {"C_join_left2", (DL_FUNC) &C_join_left2, 4},
+    {"C_join_inner2", (DL_FUNC) &C_join_inner2, 4},
     {"C_localMaxima", (DL_FUNC) &C_localMaxima, 2},
     {NULL, NULL, 0}
 };

--- a/src/join.c
+++ b/src/join.c
@@ -39,6 +39,51 @@ SEXP C_join_left(SEXP x, SEXP y, SEXP tolerance, SEXP nomatch) {
 }
 
 /**
+ * Right join of two increasingly sorted arrays.
+ *
+ * \param x array, has to be sorted increasingly and not contain any NA.
+ * \param y array, has to be sorted increasingly and not contain any NA.
+ * \param tolerance allowed tolerance to be accepted as match, has to be of
+ * length == length(x).
+ * \param nomatch value that should be returned if a key couldn't be matched.
+ * \author Sebastian Gibb
+ */
+SEXP C_join_right(SEXP x, SEXP y, SEXP tolerance, SEXP nomatch) {
+    SEXP c = PROTECT(C_closest_dup_closest(x, y, tolerance, nomatch));
+    int* pc = INTEGER(c);
+    const unsigned int nc = LENGTH(c);
+
+    const int inomatch = asInteger(nomatch);
+
+    const unsigned int ny = LENGTH(y);
+    SEXP rx = PROTECT(allocVector(INTSXP, ny));
+    int* px = INTEGER(rx);
+    SEXP ry = PROTECT(allocVector(INTSXP, ny));
+    int* py = INTEGER(ry);
+
+    for (unsigned int i = 0; i < ny; ++i) {
+        px[i] = inomatch;
+        py[i] = i + 1;
+    }
+    for (unsigned int i = 0; i < nc; ++i) {
+        if (pc[i] != inomatch)
+            px[pc[i] - 1] = i + 1;
+    }
+
+    SEXP out = PROTECT(allocVector(VECSXP, 2));
+    SEXP nms = PROTECT(allocVector(STRSXP, 2));
+    SET_VECTOR_ELT(out, 0, rx);
+    SET_VECTOR_ELT(out, 1, ry);
+    SET_STRING_ELT(nms, 0, mkChar("x"));
+    SET_STRING_ELT(nms, 1, mkChar("y"));
+    setAttrib(out, R_NamesSymbol, nms);
+
+    UNPROTECT(5);
+
+    return out;
+}
+
+/**
  * Inner join of two increasingly sorted arrays.
  *
  * \param x array, has to be sorted increasingly and not contain any NA.

--- a/src/join.c
+++ b/src/join.c
@@ -1,0 +1,229 @@
+/* Johannes Rainer
+ */
+
+#include "MsCoreUtils.h"
+
+#include <R.h>
+#include <Rinternals.h>
+#include <math.h>
+#include <Rmath.h>
+
+/**
+ * Outer join function. This function is optimized for increasingly ordered
+ * input arrays.
+ * @param x: sorted `numeric`.
+ * @param y: sorted `numeric`.
+ * @param tolerance: `numeric` of length equal `length(x)` with accepted
+ *        difference
+**/
+SEXP C_join_outer(SEXP x, SEXP y, SEXP tolerance) {
+    int lx, ly, idx, *ptresx, *ptresy, xi, yi, xi_next, yi_next;
+    double *px, *py, *tol, idiff, xdiff, ydiff;
+    SEXP resx, resy, output, names, tresx, tresy;
+    lx = LENGTH(x);
+    ly = LENGTH(y);
+    px = REAL(x);
+    py = REAL(y);
+    tol = REAL(tolerance);
+    if (lx != LENGTH(tolerance))
+        error("'tolerance' has to be of length 1 or length equal to 'length(x)'");
+    PROTECT(resx = allocVector(INTSXP, lx + ly));
+    PROTECT(resy = allocVector(INTSXP, lx + ly));
+    int *presx = INTEGER(resx);
+    int *presy = INTEGER(resy);
+    idx = -1;
+    xi = 0;
+    yi = 0;
+    xi_next = 0;
+    yi_next = 0;
+    int i_path = 0;             // 1 incremented y, -1 incremented x, 0 no.
+    int xi_last = -1;
+    int yi_last = -1;
+
+    while (xi < lx || yi < ly) {
+        idx++;
+        if (xi >= lx) {
+            yi++;
+            presx[idx] = NA_INTEGER;
+            presy[idx] = yi;
+            continue;
+        }
+        if (yi >= ly) {
+            xi++;
+            presx[idx] = xi;
+            presy[idx] = NA_INTEGER;
+            continue;
+        }
+        // Compare elements
+        idiff = fabs(px[xi] - py[yi]);
+        if (idiff <= tol[xi]) {
+            // Possible matching pair. Need to look ahead if any of the
+            // next elements have a smaller distance to ensure we're matching
+            // always the best, not the first, match.
+            // issue #66: if we're incrementing x to find better matches and
+            // then change to increment y (because of a better match) we habe
+            // to add also that match - otherwise we would miss a match. See
+            // issue #66 for details and examples.
+            xi_next = xi + 1;
+            yi_next = yi + 1;
+            presx[idx] = xi_next;
+            presy[idx] = yi_next;
+            if (xi_next < lx) xdiff = fabs(px[xi_next] - py[yi]);
+            else xdiff = R_PosInf;
+            if (yi_next < ly) ydiff = fabs(px[xi] - py[(yi_next)]);
+            else ydiff = R_PosInf;
+            if (xdiff < idiff || ydiff < idiff) {
+                if (xdiff < ydiff) {
+                    xi = xi_next;
+                    if (i_path > 0) {
+                        // issue #66
+                        idx--;
+                        presx[idx] = xi_next;
+                    }
+                    else presy[idx] = NA_INTEGER;
+                    i_path = -1;
+                }
+                else {
+                    yi = yi_next;
+                    if (i_path < 0) {
+                        // issue #66
+                        idx--;
+                        presy[idx] = yi_next;
+                    }
+                    else presx[idx] = NA_INTEGER;
+                    i_path = 1;
+                }
+            } else {
+                i_path = 0;
+                xi = xi_next;
+                yi = yi_next;
+            }
+        } else {
+            i_path = 0;
+            // Decide whether to increment i or j: in the outer join matches are
+            // expected to be ordered by value, thus, if x[i] < y[j] we add i
+            // to the result and increment it.
+            if (px[xi] < py[yi]) {
+                xi++;
+                presx[idx] = xi;
+                presy[idx] = NA_INTEGER;
+            } else {
+                yi++;
+                presx[idx] = NA_INTEGER;
+                presy[idx] = yi;
+            }
+        }
+    }
+
+    // Truncate the output vector - there might be a better implementation...
+    idx++;
+    PROTECT(tresx = allocVector(INTSXP, idx));
+    PROTECT(tresy = allocVector(INTSXP, idx));
+    ptresx = INTEGER(tresx);
+    ptresy = INTEGER(tresy);
+    /* memcpy(presx, ptresx, idx * sizeof(int)); */
+    /* memcpy(presy, ptresy, idx * sizeof(int)); */
+    for (xi = 0; xi < idx; xi++) {
+        ptresx[xi] = presx[xi];
+        ptresy[xi] = presy[xi];
+    }
+
+    PROTECT(output = allocVector(VECSXP, 2));
+    PROTECT(names = allocVector(STRSXP, 2));
+    SET_VECTOR_ELT(output, 0, tresx);
+    SET_VECTOR_ELT(output, 1, tresy);
+    SET_STRING_ELT(names, 0, mkChar("x"));
+    SET_STRING_ELT(names, 1, mkChar("y"));
+    setAttrib(output, R_NamesSymbol, names);
+
+    UNPROTECT(6);
+    return output;
+}
+
+/**
+ * Left join optimized for increasingly ordered arrays.
+ */
+SEXP C_join_left(SEXP x, SEXP y, SEXP tolerance) {
+    int lx, ly;
+    double *px, *py, *tol;
+    SEXP resx, resy, output, names;
+    lx = LENGTH(x);
+    ly = LENGTH(y);
+    px = REAL(x);
+    py = REAL(y);
+    tol = REAL(tolerance);
+    if (lx != LENGTH(tolerance))
+        error("'tolerance' has to be of length 1 or length equal to 'length(x)'");
+    PROTECT(resx = allocVector(INTSXP, lx));
+    PROTECT(resy = allocVector(INTSXP, lx));
+    int *presx = INTEGER(resx);
+    int *presy = INTEGER(resy);
+
+    double xdiff;
+    double ydiff;
+    double idiff;
+
+    int xi = 0;
+    int yi = 0;
+    int xi_next = 0;
+    int yi_next = 0;
+    int yi_last_used = -1;
+    int xi_last_used = R_PosInf;
+
+    while (xi < lx) {
+        xi_next = xi + 1;
+        if (yi < ly) {
+            yi_next = yi + 1;
+            // Difference for current pair.
+            idiff = fabs(px[xi] - py[yi]);
+            // Difference for next pairs.
+            if (xi_next < lx) xdiff = fabs(px[xi_next] - py[yi]);
+            else xdiff = R_PosInf;
+            if (yi_next < ly) ydiff = fabs(px[xi] - py[yi_next]);
+            else ydiff = R_PosInf;
+            // Do we have an acceptable match?
+            if (idiff <= tol[xi]) {
+                presx[xi] = xi_next;
+                presy[xi] = yi_next;
+                // Remove last hit with same yi if we incremented xi and will NOT
+                // increment yi next.
+                if (yi == yi_last_used && xi > xi_last_used) {
+                    // We're not incrementing yi next round.
+                    if (ydiff > idiff || ydiff > xdiff)
+                        presy[xi_last_used] = NA_INTEGER;
+                }
+                yi_last_used = yi;
+                xi_last_used = xi;
+            } else {
+                presx[xi] = xi_next;
+                presy[xi] = NA_INTEGER;
+            }
+            // Decide which index to increment.
+            if (xdiff < idiff || ydiff < idiff) {
+                // Increment the index with the smaller distance
+                if (xdiff < ydiff) xi = xi_next;
+                else yi = yi_next;
+            } else {
+                // Neither xdiff nor ydiff better than idiff, increment both
+                yi = yi_next;
+                xi = xi_next;
+            }
+        } else {
+            // Just fill-up the result.
+            presy[xi] = NA_INTEGER;
+            presx[xi] = xi_next;
+            xi = xi_next;
+        }
+    }
+
+    PROTECT(output = allocVector(VECSXP, 2));
+    PROTECT(names = allocVector(STRSXP, 2));
+    SET_VECTOR_ELT(output, 0, resx);
+    SET_VECTOR_ELT(output, 1, resy);
+    SET_STRING_ELT(names, 0, mkChar("x"));
+    SET_STRING_ELT(names, 1, mkChar("y"));
+    setAttrib(output, R_NamesSymbol, names);
+
+    UNPROTECT(4);
+    return output;
+}

--- a/src/join.c
+++ b/src/join.c
@@ -1,6 +1,3 @@
-/* Johannes Rainer
- */
-
 #include "MsCoreUtils.h"
 
 #include <R.h>
@@ -9,12 +6,87 @@
 #include <Rmath.h>
 
 /**
+ * Left join of two increasingly sorted arrays.
+ *
+ * \param x array, has to be sorted increasingly and not contain any NA.
+ * \param y array, has to be sorted increasingly and not contain any NA.
+ * \param tolerance allowed tolerance to be accepted as match, has to be of
+ * length == length(x).
+ * \param nomatch value that should be returned if a key couldn't be matched.
+ */
+SEXP C_join_left2(SEXP x, SEXP y, SEXP tolerance, SEXP nomatch) {
+    SEXP ry = PROTECT(C_closest_dup_closest(x, y, tolerance, nomatch));
+    const unsigned int ny = LENGTH(ry);
+
+    SEXP rx = PROTECT(allocVector(INTSXP, ny));
+    int* px = INTEGER(rx);
+
+    for (unsigned int i = 0; i < ny; ++i)
+        px[i] = i + 1;
+
+    SEXP out = PROTECT(allocVector(VECSXP, 2));
+    SEXP nms = PROTECT(allocVector(STRSXP, 2));
+    SET_VECTOR_ELT(out, 0, rx);
+    SET_VECTOR_ELT(out, 1, ry);
+    SET_STRING_ELT(nms, 0, mkChar("x"));
+    SET_STRING_ELT(nms, 1, mkChar("y"));
+    setAttrib(out, R_NamesSymbol, nms);
+
+    UNPROTECT(4);
+
+    return out;
+}
+
+/**
+ * Inner join of two increasingly sorted arrays.
+ *
+ * \param x array, has to be sorted increasingly and not contain any NA.
+ * \param y array, has to be sorted increasingly and not contain any NA.
+ * \param tolerance allowed tolerance to be accepted as match, has to be of
+ * length == length(x).
+ * \param nomatch value that should be returned if a key couldn't be matched.
+ */
+SEXP C_join_inner2(SEXP x, SEXP y, SEXP tolerance, SEXP nomatch) {
+    SEXP ry = PROTECT(C_closest_dup_closest(x, y, tolerance, nomatch));
+    int* py = INTEGER(ry);
+    const unsigned int ny = LENGTH(ry);
+
+    SEXP rx = PROTECT(allocVector(INTSXP, ny));
+    int* px = INTEGER(rx);
+
+    const int inomatch = asInteger(nomatch);
+    unsigned int j = 0;
+
+    for (unsigned int i = 0; i < ny; ++i) {
+        if (py[i] != inomatch) {
+            px[j] = i + 1;
+            py[j] = py[i];
+            ++j;
+        }
+    }
+    SETLENGTH(rx, j);
+    SETLENGTH(ry, j);
+    SEXP out = PROTECT(allocVector(VECSXP, 2));
+    SEXP nms = PROTECT(allocVector(STRSXP, 2));
+    SET_VECTOR_ELT(out, 0, rx);
+    SET_VECTOR_ELT(out, 1, ry);
+    SET_STRING_ELT(nms, 0, mkChar("x"));
+    SET_STRING_ELT(nms, 1, mkChar("y"));
+    setAttrib(out, R_NamesSymbol, nms);
+
+    UNPROTECT(4);
+
+    return out;
+}
+
+/**
  * Outer join function. This function is optimized for increasingly ordered
  * input arrays.
  * @param x: sorted `numeric`.
  * @param y: sorted `numeric`.
  * @param tolerance: `numeric` of length equal `length(x)` with accepted
  *        difference
+ * @author: Johannes Rainer
 **/
 SEXP C_join_outer(SEXP x, SEXP y, SEXP tolerance) {
     int lx, ly, idx, *ptresx, *ptresy, xi, yi, xi_next, yi_next;
@@ -226,4 +298,84 @@ SEXP C_join_left(SEXP x, SEXP y, SEXP tolerance) {
 
     UNPROTECT(4);
     return output;
+}
+
+SEXP C_join_outer2(SEXP x, SEXP y, SEXP tolerance, SEXP nomatch) {
+    double *pix = REAL(x);
+    const unsigned int nx = LENGTH(x);
+    double *piy = REAL(y);
+    const unsigned int ny = LENGTH(y);
+
+    double *ptolerance = REAL(tolerance);
+
+    const unsigned int inomatch = asInteger(nomatch);
+
+    SEXP rx = PROTECT(allocVector(INTSXP, nx + ny));
+    SEXP ry = PROTECT(allocVector(INTSXP, nx + ny));
+
+    int* prx = INTEGER(rx);
+    int* pry = INTEGER(ry);
+
+    unsigned int i = 0, ix = 0, iy = 0;
+    double diff = R_PosInf, diffnxtx = R_PosInf, diffnxty = R_PosInf, diffnxtxy = R_PosInf;
+
+    while (ix < nx || iy < ny) {
+        if (ix >= nx) {
+            prx[i] = inomatch;
+            pry[i] = ++iy;
+        } else if (iy >= ny) {
+            prx[i] = ++ix;
+            pry[i] = inomatch;
+        } else {
+            /* difference for current pair */
+            diff = fabs(pix[ix] - piy[iy]);
+
+            if (diff <= ptolerance[ix]) {
+                /* difference for next pairs */
+                diffnxtx =
+                    ix + 1 < nx ? fabs(pix[ix + 1] - piy[iy]) : R_PosInf;
+                diffnxty =
+                    iy + 1 < ny ? fabs(pix[ix] - piy[iy + 1]) : R_PosInf;
+                diffnxtxy =
+                    (ix + 1 < nx && iy + 1 < ny) ? fabs(pix[ix + 1] - piy[iy + 1]) : R_PosInf;
+
+                if ((diffnxtx < diff && diffnxtx < diffnxtxy) ||
+                        (diffnxty < diff && diffnxty < diffnxtxy)) {
+                    if (diffnxtx < diffnxty) {
+                        prx[i] = ++ix;
+                        pry[i] = inomatch;
+                    } else {
+                        prx[i] = inomatch;
+                        pry[i] = ++iy;
+                    }
+                } else {
+                    prx[i] = ++ix;
+                    pry[i] = ++iy;
+                }
+            } else {
+                if (pix[ix] < piy[iy]) {
+                    prx[i] = ++ix;
+                    pry[i] = inomatch;
+                } else {
+                    prx[i] = inomatch;
+                    pry[i] = ++iy;
+                }
+            }
+        }
+        ++i;
+    }
+
+    SETLENGTH(rx, i);
+    SETLENGTH(ry, i);
+    SEXP out = PROTECT(allocVector(VECSXP, 2));
+    SEXP nms = PROTECT(allocVector(STRSXP, 2));
+    SET_VECTOR_ELT(out, 0, rx);
+    SET_VECTOR_ELT(out, 1, ry);
+    SET_STRING_ELT(nms, 0, mkChar("x"));
+    SET_STRING_ELT(nms, 1, mkChar("y"));
+    setAttrib(out, R_NamesSymbol, nms);
+
+    UNPROTECT(4);
+
+    return out;
 }

--- a/src/join.c
+++ b/src/join.c
@@ -13,8 +13,9 @@
  * \param tolerance allowed tolerance to be accepted as match, has to be of
  * length == length(x).
  * \param nomatch value that should be returned if a key couldn't be matched.
+ * \author Sebastian Gibb
  */
-SEXP C_join_left2(SEXP x, SEXP y, SEXP tolerance, SEXP nomatch) {
+SEXP C_join_left(SEXP x, SEXP y, SEXP tolerance, SEXP nomatch) {
     SEXP ry = PROTECT(C_closest_dup_closest(x, y, tolerance, nomatch));
     const unsigned int ny = LENGTH(ry);
 
@@ -45,8 +46,9 @@ SEXP C_join_left2(SEXP x, SEXP y, SEXP tolerance, SEXP nomatch) {
  * \param tolerance allowed tolerance to be accepted as match, has to be of
  * length == length(x).
  * \param nomatch value that should be returned if a key couldn't be matched.
+ * \author Sebastian Gibb
  */
-SEXP C_join_inner2(SEXP x, SEXP y, SEXP tolerance, SEXP nomatch) {
+SEXP C_join_inner(SEXP x, SEXP y, SEXP tolerance, SEXP nomatch) {
     SEXP ry = PROTECT(C_closest_dup_closest(x, y, tolerance, nomatch));
     int* py = INTEGER(ry);
     const unsigned int ny = LENGTH(ry);
@@ -80,227 +82,16 @@ SEXP C_join_inner2(SEXP x, SEXP y, SEXP tolerance, SEXP nomatch) {
 }
 
 /**
- * Outer join function. This function is optimized for increasingly ordered
- * input arrays.
- * @param x: sorted `numeric`.
- * @param y: sorted `numeric`.
- * @param tolerance: `numeric` of length equal `length(x)` with accepted
- *        difference
- * @author: Johannes Rainer
-**/
-SEXP C_join_outer(SEXP x, SEXP y, SEXP tolerance) {
-    int lx, ly, idx, *ptresx, *ptresy, xi, yi, xi_next, yi_next;
-    double *px, *py, *tol, idiff, xdiff, ydiff;
-    SEXP resx, resy, output, names, tresx, tresy;
-    lx = LENGTH(x);
-    ly = LENGTH(y);
-    px = REAL(x);
-    py = REAL(y);
-    tol = REAL(tolerance);
-    if (lx != LENGTH(tolerance))
-        error("'tolerance' has to be of length 1 or length equal to 'length(x)'");
-    PROTECT(resx = allocVector(INTSXP, lx + ly));
-    PROTECT(resy = allocVector(INTSXP, lx + ly));
-    int *presx = INTEGER(resx);
-    int *presy = INTEGER(resy);
-    idx = -1;
-    xi = 0;
-    yi = 0;
-    xi_next = 0;
-    yi_next = 0;
-    int i_path = 0;             // 1 incremented y, -1 incremented x, 0 no.
-    int xi_last = -1;
-    int yi_last = -1;
-
-    while (xi < lx || yi < ly) {
-        idx++;
-        if (xi >= lx) {
-            yi++;
-            presx[idx] = NA_INTEGER;
-            presy[idx] = yi;
-            continue;
-        }
-        if (yi >= ly) {
-            xi++;
-            presx[idx] = xi;
-            presy[idx] = NA_INTEGER;
-            continue;
-        }
-        // Compare elements
-        idiff = fabs(px[xi] - py[yi]);
-        if (idiff <= tol[xi]) {
-            // Possible matching pair. Need to look ahead if any of the
-            // next elements have a smaller distance to ensure we're matching
-            // always the best, not the first, match.
-            // issue #66: if we're incrementing x to find better matches and
-            // then change to increment y (because of a better match) we habe
-            // to add also that match - otherwise we would miss a match. See
-            // issue #66 for details and examples.
-            xi_next = xi + 1;
-            yi_next = yi + 1;
-            presx[idx] = xi_next;
-            presy[idx] = yi_next;
-            if (xi_next < lx) xdiff = fabs(px[xi_next] - py[yi]);
-            else xdiff = R_PosInf;
-            if (yi_next < ly) ydiff = fabs(px[xi] - py[(yi_next)]);
-            else ydiff = R_PosInf;
-            if (xdiff < idiff || ydiff < idiff) {
-                if (xdiff < ydiff) {
-                    xi = xi_next;
-                    if (i_path > 0) {
-                        // issue #66
-                        idx--;
-                        presx[idx] = xi_next;
-                    }
-                    else presy[idx] = NA_INTEGER;
-                    i_path = -1;
-                }
-                else {
-                    yi = yi_next;
-                    if (i_path < 0) {
-                        // issue #66
-                        idx--;
-                        presy[idx] = yi_next;
-                    }
-                    else presx[idx] = NA_INTEGER;
-                    i_path = 1;
-                }
-            } else {
-                i_path = 0;
-                xi = xi_next;
-                yi = yi_next;
-            }
-        } else {
-            i_path = 0;
-            // Decide whether to increment i or j: in the outer join matches are
-            // expected to be ordered by value, thus, if x[i] < y[j] we add i
-            // to the result and increment it.
-            if (px[xi] < py[yi]) {
-                xi++;
-                presx[idx] = xi;
-                presy[idx] = NA_INTEGER;
-            } else {
-                yi++;
-                presx[idx] = NA_INTEGER;
-                presy[idx] = yi;
-            }
-        }
-    }
-
-    // Truncate the output vector - there might be a better implementation...
-    idx++;
-    PROTECT(tresx = allocVector(INTSXP, idx));
-    PROTECT(tresy = allocVector(INTSXP, idx));
-    ptresx = INTEGER(tresx);
-    ptresy = INTEGER(tresy);
-    /* memcpy(presx, ptresx, idx * sizeof(int)); */
-    /* memcpy(presy, ptresy, idx * sizeof(int)); */
-    for (xi = 0; xi < idx; xi++) {
-        ptresx[xi] = presx[xi];
-        ptresy[xi] = presy[xi];
-    }
-
-    PROTECT(output = allocVector(VECSXP, 2));
-    PROTECT(names = allocVector(STRSXP, 2));
-    SET_VECTOR_ELT(output, 0, tresx);
-    SET_VECTOR_ELT(output, 1, tresy);
-    SET_STRING_ELT(names, 0, mkChar("x"));
-    SET_STRING_ELT(names, 1, mkChar("y"));
-    setAttrib(output, R_NamesSymbol, names);
-
-    UNPROTECT(6);
-    return output;
-}
-
-/**
- * Left join optimized for increasingly ordered arrays.
+ * Outer join of two increasingly sorted arrays.
+ *
+ * \param x array, has to be sorted increasingly and not contain any NA.
+ * \param y array, has to be sorted increasingly and not contain any NA.
+ * \param tolerance allowed tolerance to be accepted as match, has to be of
+ * length == length(x).
+ * \param nomatch value that should be returned if a key couldn't be matched.
+ * \author Johannes Rainer, Sebastian Gibb
  */
-SEXP C_join_left(SEXP x, SEXP y, SEXP tolerance) {
-    int lx, ly;
-    double *px, *py, *tol;
-    SEXP resx, resy, output, names;
-    lx = LENGTH(x);
-    ly = LENGTH(y);
-    px = REAL(x);
-    py = REAL(y);
-    tol = REAL(tolerance);
-    if (lx != LENGTH(tolerance))
-        error("'tolerance' has to be of length 1 or length equal to 'length(x)'");
-    PROTECT(resx = allocVector(INTSXP, lx));
-    PROTECT(resy = allocVector(INTSXP, lx));
-    int *presx = INTEGER(resx);
-    int *presy = INTEGER(resy);
-
-    double xdiff;
-    double ydiff;
-    double idiff;
-
-    int xi = 0;
-    int yi = 0;
-    int xi_next = 0;
-    int yi_next = 0;
-    int yi_last_used = -1;
-    int xi_last_used = R_PosInf;
-
-    while (xi < lx) {
-        xi_next = xi + 1;
-        if (yi < ly) {
-            yi_next = yi + 1;
-            // Difference for current pair.
-            idiff = fabs(px[xi] - py[yi]);
-            // Difference for next pairs.
-            if (xi_next < lx) xdiff = fabs(px[xi_next] - py[yi]);
-            else xdiff = R_PosInf;
-            if (yi_next < ly) ydiff = fabs(px[xi] - py[yi_next]);
-            else ydiff = R_PosInf;
-            // Do we have an acceptable match?
-            if (idiff <= tol[xi]) {
-                presx[xi] = xi_next;
-                presy[xi] = yi_next;
-                // Remove last hit with same yi if we incremented xi and will NOT
-                // increment yi next.
-                if (yi == yi_last_used && xi > xi_last_used) {
-                    // We're not incrementing yi next round.
-                    if (ydiff > idiff || ydiff > xdiff)
-                        presy[xi_last_used] = NA_INTEGER;
-                }
-                yi_last_used = yi;
-                xi_last_used = xi;
-            } else {
-                presx[xi] = xi_next;
-                presy[xi] = NA_INTEGER;
-            }
-            // Decide which index to increment.
-            if (xdiff < idiff || ydiff < idiff) {
-                // Increment the index with the smaller distance
-                if (xdiff < ydiff) xi = xi_next;
-                else yi = yi_next;
-            } else {
-                // Neither xdiff nor ydiff better than idiff, increment both
-                yi = yi_next;
-                xi = xi_next;
-            }
-        } else {
-            // Just fill-up the result.
-            presy[xi] = NA_INTEGER;
-            presx[xi] = xi_next;
-            xi = xi_next;
-        }
-    }
-
-    PROTECT(output = allocVector(VECSXP, 2));
-    PROTECT(names = allocVector(STRSXP, 2));
-    SET_VECTOR_ELT(output, 0, resx);
-    SET_VECTOR_ELT(output, 1, resy);
-    SET_STRING_ELT(names, 0, mkChar("x"));
-    SET_STRING_ELT(names, 1, mkChar("y"));
-    setAttrib(output, R_NamesSymbol, names);
-
-    UNPROTECT(4);
-    return output;
-}
-
-SEXP C_join_outer2(SEXP x, SEXP y, SEXP tolerance, SEXP nomatch) {
+SEXP C_join_outer(SEXP x, SEXP y, SEXP tolerance, SEXP nomatch) {
     double *pix = REAL(x);
     const unsigned int nx = LENGTH(x);
     double *piy = REAL(y);

--- a/tests/testthat/test_matching.R
+++ b/tests/testthat/test_matching.R
@@ -101,11 +101,13 @@ test_that("common", {
 })
 
 test_that("join", {
-    x <- c(1, 2, 3, 6)
-    y <- c(3, 4, 5, 6, 7)
+    x <- as.numeric(c(1, 2, 3, 6))
+    y <- as.numeric(c(3, 4, 5, 6, 7))
 
     expect_equal(join(x, y, type = "outer"),
                  list(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, 1:5)))
+    expect_equal(.joinOuter(x, y, 0, 0),
+                 .cjoinOuter(x, y, 0, 0))
     expect_equal(join(x, y, type = "left"),
                  list(x = 1:4, y = c(NA, NA, 1, 4)))
     expect_equal(join(x, y, type = "right"),
@@ -117,6 +119,8 @@ test_that("join", {
     expect_equal(join(x, y, type = "outer"),
                  list(x = c(1:3, rep(NA, 4), 4, NA),
                       y = c(rep(NA, 3), 1:4, NA, 5)))
+    expect_equal(.joinOuter(x, y, 0, 0),
+                 .cjoinOuter(x, y, 0, 0))
     expect_equal(join(x, y, type = "left"),
                  list(x = 1:4, y = rep(NA_integer_, 4)))
     expect_equal(join(x, y, type = "right"),
@@ -125,6 +129,8 @@ test_that("join", {
                  list(x = integer(), y = integer()))
     expect_equal(join(x, y, tolerance = 0.1, type = "outer"),
                  list(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, 1:5)))
+    expect_equal(.joinOuter(x, y, 0.1, 0),
+                 .cjoinOuter(x, y, 0.1, 0))
     expect_equal(join(x, y, tolerance = 0.1, type = "left"),
                  list(x = 1:4, y = c(NA, NA, 1, 4)))
     expect_equal(join(x, y, tolerance = 0.1, type = "right"),
@@ -136,6 +142,8 @@ test_that("join", {
     expect_equal(join(x, y, tolerance = 0.1, type = "outer"),
                  list(x = c(1:3, rep(NA, 4), 4, NA),
                       y = c(rep(NA, 3), 1:4, NA, 5)))
+    expect_equal(.joinOuter(x, y, 0.1, 0),
+                 .cjoinOuter(x, y, 0.1, 0))
     expect_equal(join(x, y, tolerance = 0.1, type = "left"),
                  list(x = 1:4, y = rep(NA_integer_, 4)))
     expect_equal(join(x, y, tolerance = 0.1, type = "right"),
@@ -144,6 +152,8 @@ test_that("join", {
                  list(x = integer(), y = integer()))
     expect_equal(join(x, y, tolerance = 0.1, ppm = 2, type = "outer"),
                  list(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, 1:5)))
+    expect_equal(.joinOuter(x, y, 0.1, 2),
+                 .cjoinOuter(x, y, 0.1, 2))
     expect_equal(join(x, y, tolerance = 0.1, ppm = 2, type = "left"),
                  list(x = 1:4, y = c(NA, NA, 1, 4)))
     expect_equal(join(x, y, tolerance = 0.1, ppm = 2, type = "right"),
@@ -160,8 +170,185 @@ test_that("join", {
                  list(x = integer(), y = integer()))
 
     ## no match at all
-    x <- c(1, 2, 3, 6)
-    y <- c(4, 5, 7)
+    x <- as.numeric(c(1, 2, 3, 6))
+    y <- as.numeric(c(4, 5, 7))
     expect_equal(join(x, y, type = "outer"),
                  list(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, NA, 1:2, NA, 3)))
+})
+
+test_that(".cjoinOuter works", {
+    x <- as.numeric(c(1, 2, 3, 6))
+    y <- as.numeric(c(3, 4, 5, 6, 7))
+
+    expect_error(.cjoinOuter(1:3, 4:1, 0, 0), "sorted")
+    expect_error(.cjoinOuter(4:1, 1:4, 0, 0), "sorted")
+    expect_error(.cjoinOuter(c(1, 2, NA, 3), 1:4, 0, 0), "sorted")
+
+    expect_equal(.cjoinOuter(x, y, 0, 0),
+                 list(x = c(1, 2, 3, NA, NA, 4, NA),
+                      y = c(NA, NA, 1, 2, 3, 4, 5)))
+    expect_equal(.cjoinOuter(x, y, 10, 0),
+                 list(x = c(1, 2, 3, NA, NA, 4, NA),
+                      y = c(NA, NA, 1, 2, 3, 4, 5)))
+    expect_equal(.cjoinOuter(y, x, 10, 0),
+                 list(x = c(NA, NA, 1, 2, 3, 4, 5),
+                      y = c(1, 2, 3, NA, NA, 4, NA)))
+    expect_equal(.cjoinOuter(x, y, 0, 0),
+                 .joinOuter(x, y, 0, 0))
+    expect_equal(.cjoinOuter(x, y, 10, 0),
+                 .joinOuter(x, y, 10, 0))
+    expect_equal(.cjoinOuter(y, x, 10, 0),
+                 .joinOuter(y, x, 10, 0))
+
+    x <- c(1, 1.5, 2, 2.1, 5, 6, 7)
+    y <- c(4.6, 4.7, 4.8, 4.9, 5, 6, 7, 8)
+    expect_equal(.cjoinOuter(x, y, 0, 0),
+                 list(x = c(1:4, NA, NA, NA, NA, 5:7, NA),
+                      y = c(NA, NA, NA, NA, 1:8)))
+    expect_equal(.cjoinOuter(y, x, 0, 0),
+                 list(x = c(NA, NA, NA, NA, 1:8),
+                      y = c(1:4, NA, NA, NA, NA, 5:7, NA)))
+    ## Issue #66: outer join with tolerance 3: expect to have more matches!
+    tol_3 <- list(x = c(1, 2, 3, 4, NA, NA, NA, 5, 6, 7, NA),
+                  y = c(NA, NA, NA, 1, 2, 3, 4, 5, 6, 7, 8))
+    expect_equal(.cjoinOuter(x, y, 3, 0), tol_3)
+    tol_3 <- tol_3[2:1]
+    names(tol_3) <- c("x", "y")
+    expect_equal(.cjoinOuter(y, x, 3, 0), tol_3)
+
+    expect_equal(.cjoinOuter(x, y, 0, 0),
+                 .joinOuter(x, y, 0, 0))
+    expect_equal(.cjoinOuter(y, x, 0, 0),
+                 .joinOuter(y, x, 0, 0))
+    ## Issue #66: joinOuter fails.
+    expect_error(expect_equal(.cjoinOuter(x, y, 3, 0),
+                              .joinOuter(x, y, 3, 0)))
+
+    x <- c(1, 1.5, 2, 2.1, 3, 3.4, 4.1, 4.5, 5, 5.1, 5.2, 6, 14)
+    y <- c(4.6, 4.7, 4.8, 4.9, 5, 6, 7, 8)
+    tol_3 <- list(
+        x = c(1, 2, 3, 4, 5, 6, 7, 8, NA, NA, NA, 9, 10, 11, 12, NA, NA, 13),
+        y = c(NA, NA, NA, NA, NA, NA, NA, 1, 2, 3, 4, 5, NA, NA, 6, 7, 8, NA))
+    expect_equal(.cjoinOuter(x, y, 3, 0), tol_3)
+    expect_equal(.cjoinOuter(x, y, 1, 0),
+                 .joinOuter(x, y, 1, 0))
+
+    x <- c(1, 2, 3, 4)
+    y <- c(6, 7, 8)
+    .cjoinOuter(x, y, 20, 0)
+    expect_equal(.cjoinOuter(x, y, 0, 0),
+                 list(x = c(1:4, NA, NA, NA), y = c(NA, NA, NA, NA, 1:3)))
+    expect_equal(.cjoinOuter(x, y, 20, 0),
+                 list(x = c(1:4, NA, NA), y = c(NA, NA, NA, 1:3)))
+    expect_equal(.cjoinOuter(x, y, 0, 0),
+                 .joinOuter(x, y, 0, 0))
+
+    ## no match at all
+    x <- as.numeric(c(1, 2, 3, 6))
+    y <- as.numeric(c(4, 5, 7))
+    expect_equal(.cjoinOuter(x, y, 0, 0),
+                 list(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, NA, 1:2, NA, 3)))
+    expect_equal(.joinOuter(x, y, 0, 0), .cjoinOuter(x, y, 0, 0))
+
+    ## multiple matches but require to match the closest only (not the first)
+    x <- c(133.0759, 133.0775, 133.9788, 133.9804, 133.9820, 133.9837)
+    y <- c(133.9755, 133.9771, 133.9788, 133.9804, 133.9820, 133.9836)
+    expect_equal(.joinOuter(x, y, 0.01, 0),
+                 list(x = c(1, 2, NA, NA, 3, 4, 5, 6),
+                      y = c(NA, NA, 1, 2, 3, 4, 5, 6)))
+    expect_equal(.cjoinOuter(x, y, 0.01, 0), .joinOuter(x, y, 0.01, 0))
+    expect_equal(.joinOuter(y, x, 0.01, 0),
+                 list(x = c(NA, NA, 1, 2, 3, 4, 5, 6),
+                      y = c(1, 2, NA, NA, 3, 4, 5, 6)))
+    expect_equal(.cjoinOuter(y, x, 0.01, 0), .joinOuter(y, x, 0.01, 0))
+
+    ## identical values
+    x <- c(3, 5, 5, 5, 6, 9)
+    y <- c(2, 4, 5, 5.5, 7)
+    expect_equal(.cjoinOuter(x, y, 0, 0),
+                 list(x = c(NA, 1, NA, 2, 3, 4, NA, 5, NA, 6),
+                      y = c(1, NA, 2, 3, NA, NA, 4, NA, 5, NA)))
+    expect_equal(.cjoinOuter(y, x, 0, 0),
+                 list(x = c(1, NA, 2, 3, NA, NA, 4, NA, 5, NA),
+                      y = c(NA, 1, NA, 2, 3, 4, NA, 5, NA, 6)))
+})
+
+test_that(".cjoinLeft works", {
+    x <- as.numeric(c(1, 2, 3, 6))
+    y <- as.numeric(c(3, 4, 5, 6, 7))
+
+    expect_error(.cjoinLeft(1:3, 4:1, 0, 0), "sorted")
+    expect_error(.cjoinLeft(4:1, 1:4, 0, 0), "sorted")
+    expect_error(.cjoinLeft(c(1, 2, NA, 3), 1:4, 0, 0), "sorted")
+
+    expect_equal(.cjoinLeft(x, y, tolerance = 0, ppm = 0),
+                 list(x = 1:4, y = c(NA, NA, 1, 4)))
+    expect_equal(.cjoinLeft(x, y, tolerance = 5, ppm = 0),
+                 list(x = 1:4, y = c(NA, NA, 1, 4)))
+    expect_equal(.joinLeft(x, y, tolerance = 0, ppm = 0),
+                 .cjoinLeft(x, y, tolerance = 0, ppm = 0))
+    expect_equal(.joinLeft(x, y, tolerance = 5, ppm = 0),
+                 .cjoinLeft(x, y, tolerance = 5, ppm = 0))
+
+    x <- as.numeric(c(1, 3, 5, 6, 8))
+    y <- as.numeric(c(3, 4, 5, 7))
+    expect_equal(.cjoinLeft(x, y, 0, 0),
+                 list(x = 1:5, y = c(NA, 1, 3, NA, NA)))
+    expect_equal(.cjoinLeft(y, x, 0, 0),
+                 list(x = 1:4, y = c(2, NA, 3, NA)))
+    expect_equal(.cjoinLeft(x, y, 1, 0),
+                 list(x = 1:5, y = c(NA, 1, 3, 4, NA)))
+    expect_equal(.cjoinLeft(y, x, 1, 0),
+                 list(x = 1:4, y = c(2, NA, 3, 4)))
+    expect_equal(.cjoinLeft(x, y, 0, 0),
+                 .joinLeft(x, y, 0, 0))
+    expect_equal(.cjoinLeft(y, x, 0, 0),
+                 .joinLeft(y, x, 0, 0))
+    ## issue #65
+    ## expect_equal(.cjoinLeft(x, y, 1, 0),
+    ##              .joinLeft(x, y, 1, 0))
+    expect_equal(.cjoinLeft(y, x, 1, 0),
+                 .joinLeft(y, x, 1, 0))
+
+    x <- c(133.0759, 133.0775, 133.9788, 133.9804, 133.9820, 133.9837)
+    y <- c(133.9755, 133.9771, 133.9788, 133.9804, 133.9820, 133.9836)
+    expect_equal(.cjoinLeft(x, y, 0, 0),
+                 list(x = 1:6, y = c(NA, NA, 3, 4, 5, NA)))
+    expect_equal(.cjoinLeft(x, y, 0.01, 0),
+                 list(x = 1:6, y = c(NA, NA, 3, 4, 5, 6)))
+    expect_equal(.cjoinLeft(x, y, 1, 0),
+                 list(x = 1:6, y = c(NA, 1, 3, 4, 5, 6)))
+    expect_equal(.joinLeft(x, y, 0, 0),
+                 .cjoinLeft(x, y, 0, 0))
+    expect_equal(.joinLeft(x, y, 0.01, 0),
+                 .cjoinLeft(x, y, 0.01, 0))
+    expect_equal(.joinLeft(x, y, 1, 0),
+                 .cjoinLeft(x, y, 1, 0))
+
+    x <- c(1, 1.5, 2, 2.1, 5, 6, 7)
+    y <- c(4.6, 4.7, 4.8, 4.9, 5, 6, 7, 8)
+    expect_equal(.cjoinLeft(x, y, 0, 0),
+                 list(x = 1:7, y = c(NA, NA, NA, NA, 5, 6, 7)))
+    expect_equal(.cjoinLeft(x, y, 1, 0),
+                 list(x = 1:7, y = c(NA, NA, NA, NA, 5, 6, 7)))
+    expect_equal(.cjoinLeft(x, y, 3, 0),
+                 list(x = 1:7, y = c(NA, NA, NA, 1, 5, 6, 7)))
+    expect_equal(.cjoinLeft(x, y, 10, 0),
+                 list(x = 1:7, y = c(NA, NA, NA, 1, 5, 6, 7)))
+    expect_equal(.cjoinLeft(y, x, 0, 0),
+                 list(x = 1:8, y = c(NA, NA, NA, NA, 5, 6, 7, NA)))
+    expect_equal(.cjoinLeft(y, x, 10, 0),
+                 list(x = 1:8, y = c(NA, NA, NA, NA, 5, 6, 7, NA)))
+    expect_equal(.cjoinLeft(x, y, 0, 0),
+                 .joinLeft(x, y, 0, 0))
+    expect_equal(.cjoinLeft(x, y, 1, 0),
+                 .joinLeft(x, y, 1, 0))
+    expect_equal(.cjoinLeft(x, y, 3, 0),
+                 .joinLeft(x, y, 3, 0))
+    expect_equal(.cjoinLeft(x, y, 10, 0),
+                 .joinLeft(x, y, 10, 0))
+    expect_equal(.cjoinLeft(y, x, 0, 0),
+                 .joinLeft(y, x, 0, 0))
+    expect_equal(.cjoinLeft(y, x, 10, 0),
+                 .joinLeft(y, x, 10, 0))
 })

--- a/tests/testthat/test_matching.R
+++ b/tests/testthat/test_matching.R
@@ -106,8 +106,6 @@ test_that("join", {
 
     expect_equal(join(x, y, type = "outer"),
                  list(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, 1:5)))
-    expect_equal(.joinOuter(x, y, 0, 0),
-                 .cjoinOuter(x, y, 0, 0))
     expect_equal(join(x, y, type = "left"),
                  list(x = 1:4, y = c(NA, NA, 1, 4)))
     expect_equal(join(x, y, type = "right"),
@@ -119,8 +117,6 @@ test_that("join", {
     expect_equal(join(x, y, type = "outer"),
                  list(x = c(1:3, rep(NA, 4), 4, NA),
                       y = c(rep(NA, 3), 1:4, NA, 5)))
-    expect_equal(.joinOuter(x, y, 0, 0),
-                 .cjoinOuter(x, y, 0, 0))
     expect_equal(join(x, y, type = "left"),
                  list(x = 1:4, y = rep(NA_integer_, 4)))
     expect_equal(join(x, y, type = "right"),
@@ -129,8 +125,6 @@ test_that("join", {
                  list(x = integer(), y = integer()))
     expect_equal(join(x, y, tolerance = 0.1, type = "outer"),
                  list(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, 1:5)))
-    expect_equal(.joinOuter(x, y, 0.1, 0),
-                 .cjoinOuter(x, y, 0.1, 0))
     expect_equal(join(x, y, tolerance = 0.1, type = "left"),
                  list(x = 1:4, y = c(NA, NA, 1, 4)))
     expect_equal(join(x, y, tolerance = 0.1, type = "right"),
@@ -142,8 +136,6 @@ test_that("join", {
     expect_equal(join(x, y, tolerance = 0.1, type = "outer"),
                  list(x = c(1:3, rep(NA, 4), 4, NA),
                       y = c(rep(NA, 3), 1:4, NA, 5)))
-    expect_equal(.joinOuter(x, y, 0.1, 0),
-                 .cjoinOuter(x, y, 0.1, 0))
     expect_equal(join(x, y, tolerance = 0.1, type = "left"),
                  list(x = 1:4, y = rep(NA_integer_, 4)))
     expect_equal(join(x, y, tolerance = 0.1, type = "right"),
@@ -152,8 +144,6 @@ test_that("join", {
                  list(x = integer(), y = integer()))
     expect_equal(join(x, y, tolerance = 0.1, ppm = 2, type = "outer"),
                  list(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, 1:5)))
-    expect_equal(.joinOuter(x, y, 0.1, 2),
-                 .cjoinOuter(x, y, 0.1, 2))
     expect_equal(join(x, y, tolerance = 0.1, ppm = 2, type = "left"),
                  list(x = 1:4, y = c(NA, NA, 1, 4)))
     expect_equal(join(x, y, tolerance = 0.1, ppm = 2, type = "right"),
@@ -176,179 +166,117 @@ test_that("join", {
                  list(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, NA, 1:2, NA, 3)))
 })
 
-test_that(".cjoinOuter works", {
+test_that("outer join works", {
     x <- as.numeric(c(1, 2, 3, 6))
     y <- as.numeric(c(3, 4, 5, 6, 7))
 
-    expect_error(.cjoinOuter(1:3, 4:1, 0, 0), "sorted")
-    expect_error(.cjoinOuter(4:1, 1:4, 0, 0), "sorted")
-    expect_error(.cjoinOuter(c(1, 2, NA, 3), 1:4, 0, 0), "sorted")
+    expect_error(join(1:3, 4:1, 0, 0, type = "outer"), "sorted")
+    expect_error(join(4:1, 1:4, 0, 0, type = "outer"), "sorted")
+    expect_error(join(c(1, 2, NA, 3, type = "outer"), 1:4, 0, 0), "sorted")
 
-    expect_equal(.cjoinOuter(x, y, 0, 0),
+    expect_equal(join(x, y, 0, 0, type = "outer"),
                  list(x = c(1, 2, 3, NA, NA, 4, NA),
                       y = c(NA, NA, 1, 2, 3, 4, 5)))
-    expect_equal(.cjoinOuter(x, y, 10, 0),
+    expect_equal(join(x, y, 10, 0, type = "outer"),
                  list(x = c(1, 2, 3, NA, NA, 4, NA),
                       y = c(NA, NA, 1, 2, 3, 4, 5)))
-    expect_equal(.cjoinOuter(y, x, 10, 0),
+    expect_equal(join(y, x, 10, 0, type = "outer"),
                  list(x = c(NA, NA, 1, 2, 3, 4, 5),
                       y = c(1, 2, 3, NA, NA, 4, NA)))
-    expect_equal(.cjoinOuter(x, y, 0, 0),
-                 .joinOuter(x, y, 0, 0))
-    expect_equal(.cjoinOuter(x, y, 10, 0),
-                 .joinOuter(x, y, 10, 0))
-    expect_equal(.cjoinOuter(y, x, 10, 0),
-                 .joinOuter(y, x, 10, 0))
 
     x <- c(1, 1.5, 2, 2.1, 5, 6, 7)
     y <- c(4.6, 4.7, 4.8, 4.9, 5, 6, 7, 8)
-    expect_equal(.cjoinOuter(x, y, 0, 0),
+    expect_equal(join(x, y, 0, 0, type = "outer"),
                  list(x = c(1:4, NA, NA, NA, NA, 5:7, NA),
                       y = c(NA, NA, NA, NA, 1:8)))
-    expect_equal(.cjoinOuter(y, x, 0, 0),
+    expect_equal(join(y, x, 0, 0, type = "outer"),
                  list(x = c(NA, NA, NA, NA, 1:8),
                       y = c(1:4, NA, NA, NA, NA, 5:7, NA)))
     ## Issue #66: outer join with tolerance 3: expect to have more matches!
     tol_3 <- list(x = c(1, 2, 3, 4, NA, NA, NA, 5, 6, 7, NA),
                   y = c(NA, NA, NA, 1, 2, 3, 4, 5, 6, 7, 8))
-    expect_equal(.cjoinOuter(x, y, 3, 0), tol_3)
+    expect_equal(join(x, y, 3, 0, type = "outer"), tol_3)
     tol_3 <- tol_3[2:1]
     names(tol_3) <- c("x", "y")
-    expect_equal(.cjoinOuter(y, x, 3, 0), tol_3)
-
-    expect_equal(.cjoinOuter(x, y, 0, 0),
-                 .joinOuter(x, y, 0, 0))
-    expect_equal(.cjoinOuter(y, x, 0, 0),
-                 .joinOuter(y, x, 0, 0))
-    ## Issue #66: joinOuter fails.
-    expect_error(expect_equal(.cjoinOuter(x, y, 3, 0),
-                              .joinOuter(x, y, 3, 0)))
+    expect_equal(join(y, x, 3, 0, type = "outer"), tol_3)
 
     x <- c(1, 1.5, 2, 2.1, 3, 3.4, 4.1, 4.5, 5, 5.1, 5.2, 6, 14)
     y <- c(4.6, 4.7, 4.8, 4.9, 5, 6, 7, 8)
     tol_3 <- list(
         x = c(1, 2, 3, 4, 5, 6, 7, 8, NA, NA, NA, 9, 10, 11, 12, NA, NA, 13),
         y = c(NA, NA, NA, NA, NA, NA, NA, 1, 2, 3, 4, 5, NA, NA, 6, 7, 8, NA))
-    expect_equal(.cjoinOuter(x, y, 3, 0), tol_3)
-    expect_equal(.cjoinOuter(x, y, 1, 0),
-                 .joinOuter(x, y, 1, 0))
+    expect_equal(join(x, y, 3, 0, type = "outer"), tol_3)
 
     x <- c(1, 2, 3, 4)
     y <- c(6, 7, 8)
-    .cjoinOuter(x, y, 20, 0)
-    expect_equal(.cjoinOuter(x, y, 0, 0),
+    join(x, y, 20, 0, type = "outer")
+    expect_equal(join(x, y, 0, 0, type = "outer"),
                  list(x = c(1:4, NA, NA, NA), y = c(NA, NA, NA, NA, 1:3)))
-    expect_equal(.cjoinOuter(x, y, 20, 0),
+    expect_equal(join(x, y, 20, 0, type = "outer"),
                  list(x = c(1:4, NA, NA), y = c(NA, NA, NA, 1:3)))
-    expect_equal(.cjoinOuter(x, y, 0, 0),
-                 .joinOuter(x, y, 0, 0))
 
     ## no match at all
     x <- as.numeric(c(1, 2, 3, 6))
     y <- as.numeric(c(4, 5, 7))
-    expect_equal(.cjoinOuter(x, y, 0, 0),
+    expect_equal(join(x, y, 0, 0, type = "outer"),
                  list(x = c(1:3, NA, NA, 4, NA), y = c(NA, NA, NA, 1:2, NA, 3)))
-    expect_equal(.joinOuter(x, y, 0, 0), .cjoinOuter(x, y, 0, 0))
-
-    ## multiple matches but require to match the closest only (not the first)
-    x <- c(133.0759, 133.0775, 133.9788, 133.9804, 133.9820, 133.9837)
-    y <- c(133.9755, 133.9771, 133.9788, 133.9804, 133.9820, 133.9836)
-    expect_equal(.joinOuter(x, y, 0.01, 0),
-                 list(x = c(1, 2, NA, NA, 3, 4, 5, 6),
-                      y = c(NA, NA, 1, 2, 3, 4, 5, 6)))
-    expect_equal(.cjoinOuter(x, y, 0.01, 0), .joinOuter(x, y, 0.01, 0))
-    expect_equal(.joinOuter(y, x, 0.01, 0),
-                 list(x = c(NA, NA, 1, 2, 3, 4, 5, 6),
-                      y = c(1, 2, NA, NA, 3, 4, 5, 6)))
-    expect_equal(.cjoinOuter(y, x, 0.01, 0), .joinOuter(y, x, 0.01, 0))
 
     ## identical values
     x <- c(3, 5, 5, 5, 6, 9)
     y <- c(2, 4, 5, 5.5, 7)
-    expect_equal(.cjoinOuter(x, y, 0, 0),
+    expect_equal(join(x, y, 0, 0, type = "outer"),
                  list(x = c(NA, 1, NA, 2, 3, 4, NA, 5, NA, 6),
                       y = c(1, NA, 2, 3, NA, NA, 4, NA, 5, NA)))
-    expect_equal(.cjoinOuter(y, x, 0, 0),
+    expect_equal(join(y, x, 0, 0, type = "outer"),
                  list(x = c(1, NA, 2, 3, NA, NA, 4, NA, 5, NA),
                       y = c(NA, 1, NA, 2, 3, 4, NA, 5, NA, 6)))
 })
 
-test_that(".cjoinLeft works", {
+test_that("left join works", {
     x <- as.numeric(c(1, 2, 3, 6))
     y <- as.numeric(c(3, 4, 5, 6, 7))
 
-    expect_error(.cjoinLeft(1:3, 4:1, 0, 0), "sorted")
-    expect_error(.cjoinLeft(4:1, 1:4, 0, 0), "sorted")
-    expect_error(.cjoinLeft(c(1, 2, NA, 3), 1:4, 0, 0), "sorted")
+    expect_error(join(1:3, 4:1, 0, 0, type = "left"), "sorted")
+    expect_error(join(4:1, 1:4, 0, 0, type = "left"), "sorted")
+    expect_error(join(c(1, 2, NA, 3, type = "left"), 1:4, 0, 0), "sorted")
 
-    expect_equal(.cjoinLeft(x, y, tolerance = 0, ppm = 0),
+    expect_equal(join(x, y, tolerance = 0, ppm = 0, type = "left"),
                  list(x = 1:4, y = c(NA, NA, 1, 4)))
-    expect_equal(.cjoinLeft(x, y, tolerance = 5, ppm = 0),
+    expect_equal(join(x, y, tolerance = 5, ppm = 0, type = "left"),
                  list(x = 1:4, y = c(NA, NA, 1, 4)))
-    expect_equal(.joinLeft(x, y, tolerance = 0, ppm = 0),
-                 .cjoinLeft(x, y, tolerance = 0, ppm = 0))
-    expect_equal(.joinLeft(x, y, tolerance = 5, ppm = 0),
-                 .cjoinLeft(x, y, tolerance = 5, ppm = 0))
 
     x <- as.numeric(c(1, 3, 5, 6, 8))
     y <- as.numeric(c(3, 4, 5, 7))
-    expect_equal(.cjoinLeft(x, y, 0, 0),
+    expect_equal(join(x, y, 0, 0, type = "left"),
                  list(x = 1:5, y = c(NA, 1, 3, NA, NA)))
-    expect_equal(.cjoinLeft(y, x, 0, 0),
+    expect_equal(join(y, x, 0, 0, type = "left"),
                  list(x = 1:4, y = c(2, NA, 3, NA)))
-    expect_equal(.cjoinLeft(x, y, 1, 0),
+    expect_equal(join(x, y, 1, 0, type = "left"),
                  list(x = 1:5, y = c(NA, 1, 3, 4, NA)))
-    expect_equal(.cjoinLeft(y, x, 1, 0),
+    expect_equal(join(y, x, 1, 0, type = "left"),
                  list(x = 1:4, y = c(2, NA, 3, 4)))
-    expect_equal(.cjoinLeft(x, y, 0, 0),
-                 .joinLeft(x, y, 0, 0))
-    expect_equal(.cjoinLeft(y, x, 0, 0),
-                 .joinLeft(y, x, 0, 0))
-    ## issue #65
-    ## expect_equal(.cjoinLeft(x, y, 1, 0),
-    ##              .joinLeft(x, y, 1, 0))
-    expect_equal(.cjoinLeft(y, x, 1, 0),
-                 .joinLeft(y, x, 1, 0))
 
     x <- c(133.0759, 133.0775, 133.9788, 133.9804, 133.9820, 133.9837)
     y <- c(133.9755, 133.9771, 133.9788, 133.9804, 133.9820, 133.9836)
-    expect_equal(.cjoinLeft(x, y, 0, 0),
+    expect_equal(join(x, y, 0, 0, type = "left"),
                  list(x = 1:6, y = c(NA, NA, 3, 4, 5, NA)))
-    expect_equal(.cjoinLeft(x, y, 0.01, 0),
+    expect_equal(join(x, y, 0.01, 0, type = "left"),
                  list(x = 1:6, y = c(NA, NA, 3, 4, 5, 6)))
-    expect_equal(.cjoinLeft(x, y, 1, 0),
+    expect_equal(join(x, y, 1, 0, type = "left"),
                  list(x = 1:6, y = c(NA, 1, 3, 4, 5, 6)))
-    expect_equal(.joinLeft(x, y, 0, 0),
-                 .cjoinLeft(x, y, 0, 0))
-    expect_equal(.joinLeft(x, y, 0.01, 0),
-                 .cjoinLeft(x, y, 0.01, 0))
-    expect_equal(.joinLeft(x, y, 1, 0),
-                 .cjoinLeft(x, y, 1, 0))
 
     x <- c(1, 1.5, 2, 2.1, 5, 6, 7)
     y <- c(4.6, 4.7, 4.8, 4.9, 5, 6, 7, 8)
-    expect_equal(.cjoinLeft(x, y, 0, 0),
+    expect_equal(join(x, y, 0, 0, type = "left"),
                  list(x = 1:7, y = c(NA, NA, NA, NA, 5, 6, 7)))
-    expect_equal(.cjoinLeft(x, y, 1, 0),
+    expect_equal(join(x, y, 1, 0, type = "left"),
                  list(x = 1:7, y = c(NA, NA, NA, NA, 5, 6, 7)))
-    expect_equal(.cjoinLeft(x, y, 3, 0),
+    expect_equal(join(x, y, 3, 0, type = "left"),
                  list(x = 1:7, y = c(NA, NA, NA, 1, 5, 6, 7)))
-    expect_equal(.cjoinLeft(x, y, 10, 0),
+    expect_equal(join(x, y, 10, 0, type = "left"),
                  list(x = 1:7, y = c(NA, NA, NA, 1, 5, 6, 7)))
-    expect_equal(.cjoinLeft(y, x, 0, 0),
+    expect_equal(join(y, x, 0, 0, type = "left"),
                  list(x = 1:8, y = c(NA, NA, NA, NA, 5, 6, 7, NA)))
-    expect_equal(.cjoinLeft(y, x, 10, 0),
+    expect_equal(join(y, x, 10, 0, type = "left"),
                  list(x = 1:8, y = c(NA, NA, NA, NA, 5, 6, 7, NA)))
-    expect_equal(.cjoinLeft(x, y, 0, 0),
-                 .joinLeft(x, y, 0, 0))
-    expect_equal(.cjoinLeft(x, y, 1, 0),
-                 .joinLeft(x, y, 1, 0))
-    expect_equal(.cjoinLeft(x, y, 3, 0),
-                 .joinLeft(x, y, 3, 0))
-    expect_equal(.cjoinLeft(x, y, 10, 0),
-                 .joinLeft(x, y, 10, 0))
-    expect_equal(.cjoinLeft(y, x, 0, 0),
-                 .joinLeft(y, x, 0, 0))
-    expect_equal(.cjoinLeft(y, x, 10, 0),
-                 .joinLeft(y, x, 10, 0))
 })


### PR DESCRIPTION
This PR is a follow up to #63.

I add `*2` functions:

- `joinLeft2`: based on C implementation of `closest`.
- `joinInner2`: based on C implementation of `closest`.
- `joinOuter2`: alternative implementation (passed all @jorainer checks).

@jorainer if you are happy with this PR I would rename the functions `join*2` to `join*`. 

Benchmarking:

``` r
library("MsCoreUtils")
#> 
#> Attaching package: 'MsCoreUtils'
#> The following object is masked from 'package:stats':
#> 
#>     smooth
library("microbenchmark")

set.seed(42)
l <- list(
    small = list(x = as.numeric(c(1, 2, 5, 6)), y = as.numeric(2:5)),
    middle = list(x = sample(1000, 700), y = sample(1000, 700)),
    large = list(x = sample(1e4, 7e3), y = sample(1e4, 7e3))
)

for (i in seq(along=l)) {
    print(microbenchmark(
        rji=MsCoreUtils:::.joinInner(l[[i]]$x, l[[i]]$y, 0, 0, .check = FALSE),
        cji2=MsCoreUtils:::.cjoinInner2(l[[i]]$x, l[[i]]$y, 0, 0, .check = FALSE),
        rjl=MsCoreUtils:::.joinLeft(l[[i]]$x, l[[i]]$y, 0, 0, .check = FALSE),
        cjl=MsCoreUtils:::.cjoinLeft(l[[i]]$x, l[[i]]$y, 0, 0, .check = FALSE),
        cjl2=MsCoreUtils:::.cjoinLeft2(l[[i]]$x, l[[i]]$y, 0, 0, .check = FALSE),
        rjo=MsCoreUtils:::.joinOuter(l[[i]]$x, l[[i]]$y, 0, 0, .check = FALSE),
        cjo=MsCoreUtils:::.cjoinOuter(l[[i]]$x, l[[i]]$y, 0, 0, .check = FALSE),
        cjo2=MsCoreUtils:::.cjoinOuter2(l[[i]]$x, l[[i]]$y, 0, 0, .check = FALSE),
        times=1000
    ))
}
#> Unit: microseconds
#>  expr    min       lq      mean   median       uq      max neval cld
#>   rji 20.620  23.2730  31.52516  26.1165  30.8675 2639.286  1000  b 
#>  cji2 14.065  16.1325  26.40565  18.4565  22.1565 5282.482  1000 ab 
#>   rjl 18.842  21.2095  27.13636  24.2275  28.2555  322.786  1000 ab 
#>   cjl 14.125  16.0735  20.74852  17.8030  22.2600  143.010  1000 a  
#>  cjl2 13.961  16.0315  20.64017  17.7620  22.0360  139.103  1000 a  
#>   rjo 94.732 102.0545 125.43764 113.8755 131.4050  973.857  1000   c
#>   cjo 14.326  16.3145  20.63530  18.1070  21.8445  188.517  1000 a  
#>  cjo2 14.365  16.2380  23.84863  18.1215  22.2975 3107.251  1000 ab 
#> Unit: microseconds
#>  expr     min       lq      mean   median       uq      max neval cld
#>   rji  39.270  49.5365  61.40765  54.0425  61.2025 3817.634  1000  b 
#>  cji2  28.882  34.8995  46.29697  38.8995  45.0765 4237.321  1000 ab 
#>   rjl  32.568  39.3350  47.17911  43.6635  51.1260  115.802  1000 ab 
#>   cjl  32.745  39.8175  45.67845  42.5800  47.6855  109.518  1000 ab 
#>  cjl2  29.022  34.7210  46.04631  38.5065  45.2140 3846.289  1000 ab 
#>   rjo 369.231 400.3830 456.56043 424.7425 451.6440 4496.273  1000   c
#>   cjo  32.488  36.8160  46.54758  39.5435  44.6115 3775.743  1000 ab 
#>  cjo2  25.959  29.6540  35.30688  32.1210  36.7880   97.501  1000 a  
#> Unit: microseconds
#>  expr      min        lq      mean    median        uq        max neval cld
#>   rji  255.179  291.4835  330.2073  303.6170  322.3850   3410.494  1000  a 
#>  cji2  219.861  247.9815  281.9113  259.2330  274.2205   3674.138  1000  a 
#>   rjl  216.971  246.5600  468.8994  257.2580  274.4585 186096.679  1000  a 
#>   cjl  233.327  262.0070  310.9704  273.6015  287.5445   3246.580  1000  a 
#>  cjl2  218.626  244.3850  275.9357  255.8520  271.1545   3205.900  1000  a 
#>   rjo 3813.458 4251.7245 4803.9301 4376.5970 4623.1240 196902.537  1000   b
#>   cjo  190.052  215.0555  288.0766  225.3840  242.4155   4262.208  1000  a 
#>  cjo2  124.355  143.6855  192.6800  151.9820  164.2595   3268.108  1000  a
```

<sup>Created on 2020-09-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Closes #63 .