### PR TITLE
refactor: function bin gains `returnMids` parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MsCoreUtils
 Title: Core Utils for Mass Spectrometry Data
-Version: 1.7.4
+Version: 1.7.5
 Description: MsCoreUtils defines low-level functions for mass
     spectrometry data and is independent of any high-level data
     structures. These functions include mass spectra processing

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # MsCoreUtils 1.7
 
+## MsCoreUtils 1.7.5
+
+- Function `bin` gains parameter `returnMids` to choose whether or not bin
+  mid-points should be returned in the result `list`.
+
 ## MsCoreUtils 1.7.4
 
 - Fix `ppm` to always return a positive value (issue

--- a/R/binning.R
+++ b/R/binning.R
@@ -16,10 +16,22 @@
 #' @param breaks `numeric` defining the breaks (bins).
 #'
 #' @param FUN `function` to be used to aggregate values of `x` falling into the
-#'     bins defined by `breaks`.
+#'     bins defined by `breaks`. `FUN` is expected to return a `numeric(1)`.
 #'
-#' @return `list` with elements `x` (aggregated values of `x`) and `mids` (the
-#'     bin mid points).
+#' @param returnMids `logical(1)` whether the midpoints for the breaks should be
+#'     returned in addition to the binned (aggregated) values of `x`. Setting
+#'     `returnMids = FALSE` might be useful if the breaks are defined before
+#'     hand and binning needs to be performed on a large set of values (i.e.
+#'     within a loop for multiple pairs of `x` and `y` values).
+#'
+#' @return
+#'
+#' Depending on the value of `returnMids`:
+#'
+#' - `returnMids = TRUE` (the default): returns a `list` with elements `x`
+#'   (aggregated values of `x`) and `mids` (the bin mid points).
+#' - `returnMids = FALSE`: returns a `numeric` with just the binned values for
+#'   `x`.
 #'
 #' @author Johannes Rainer, Sebastian Gibb
 #'
@@ -38,9 +50,13 @@
 #'
 #' ## Repeat but summing up intensities instead of taking the max
 #' bin(ints, mz, size = 2, FUN = sum)
+#'
+#' ## Get only the binned values without the bin mid points.
+#' bin(ints, mz, size = 2, returnMids = FALSE)
 bin <- function(x, y, size = 1,
                 breaks = seq(floor(min(y)),
-                             ceiling(max(y)), by = size), FUN = max) {
+                             ceiling(max(y)), by = size), FUN = max,
+                returnMids = TRUE) {
     if (length(x) != length(y))
         stop("lengths of 'x' and 'y' have to match.")
     FUN <- match.fun(FUN)
@@ -52,9 +68,10 @@ bin <- function(x, y, size = 1,
     idx[idx >= nbrks] <- nbrks - 1L
 
     ints <- double(nbrks - 1L)
-    ints[unique(idx)] <- unlist(lapply(base::split(x, idx), FUN),
-                                use.names = FALSE)
-    list(x = ints, mids = (breaks[-nbrks] + breaks[-1L]) / 2L)
+    ints[unique(idx)] <- vapply(base::split(x, idx), FUN, numeric(1))
+    if (returnMids)
+        list(x = ints, mids = (breaks[-nbrks] + breaks[-1L]) / 2L)
+    else ints
 }
 
 #' Simple function to ensure that breaks (for binning) are spaning at least the

--- a/man/binning.Rd
+++ b/man/binning.Rd
@@ -9,7 +9,8 @@ bin(
   y,
   size = 1,
   breaks = seq(floor(min(y)), ceiling(max(y)), by = size),
-  FUN = max
+  FUN = max,
+  returnMids = TRUE
 )
 }
 \arguments{
@@ -23,11 +24,22 @@ the binning.}
 \item{breaks}{\code{numeric} defining the breaks (bins).}
 
 \item{FUN}{\code{function} to be used to aggregate values of \code{x} falling into the
-bins defined by \code{breaks}.}
+bins defined by \code{breaks}. \code{FUN} is expected to return a \code{numeric(1)}.}
+
+\item{returnMids}{\code{logical(1)} whether the midpoints for the breaks should be
+returned in addition to the binned (aggregated) values of \code{x}. Setting
+\code{returnMids = FALSE} might be useful if the breaks are defined before
+hand and binning needs to be performed on a large set of values (i.e.
+within a loop for multiple pairs of \code{x} and \code{y} values).}
 }
 \value{
-\code{list} with elements \code{x} (aggregated values of \code{x}) and \code{mids} (the
-bin mid points).
+Depending on the value of \code{returnMids}:
+\itemize{
+\item \code{returnMids = TRUE} (the default): returns a \code{list} with elements \code{x}
+(aggregated values of \code{x}) and \code{mids} (the bin mid points).
+\item \code{returnMids = FALSE}: returns a \code{numeric} with just the binned values for
+\code{x}.
+}
 }
 \description{
 Aggregate values in \code{x} for bins defined on \code{y}: all values
@@ -45,6 +57,9 @@ bin(ints, mz, size = 2)
 
 ## Repeat but summing up intensities instead of taking the max
 bin(ints, mz, size = 2, FUN = sum)
+
+## Get only the binned values without the bin mid points.
+bin(ints, mz, size = 2, returnMids = FALSE)
 }
 \seealso{
 Other grouping/matching functions: 

--- a/tests/testthat/test_binning.R
+++ b/tests/testthat/test_binning.R
@@ -43,6 +43,10 @@ test_that("bin works", {
     res <- bin(vals, xs, size = 3, FUN = sum)
     ## The largest bin should contain all values larger than max(brks)
     expect_equal(res$x[length(res$x)], sum(vals[xs >= max(brks)]))
+    ## without reporting mid points.
+    res_2 <- bin(vals, xs, size = 3, FUN = sum, returnMids = FALSE)
+    expect_true(is.numeric(res_2))
+    expect_equal(res$x, res_2)
 
     ## Check exceptions
     expect_error(bin(1:3, 1:5))


### PR DESCRIPTION
- Add parameter `returnMids` to disable automatic return of bin midpoints in the
  `bin` function. Using `returnMids = FALSE` will have a considerable impact on
  performance if `bin` is used on multiple pairs of `x` and `y` values (e.g.
  multiple spectra) in a loop and when breaks can be determined beforehand.