### PR TITLE
Provide compatibility with HDF5Matrix

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -258,8 +258,8 @@ jobs:
       - name: Deploy package
         if: github.ref == 'refs/heads/master' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: |
-          git global --local user.email "actions@github.com"
-          git global --local user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
           git config --global --add safe.directory /__w/MsCoreUtils/MsCoreUtils
           Rscript -e "pkgdown::deploy_to_branch(new_process = FALSE)"
         shell: bash {0}

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -196,6 +196,7 @@ jobs:
       - name: Install HDF5Array for unit tests
         run: |
           BiocManager::install("HDF5Array")
+        shell: Rscript {0}
 
       - name: Install covr
         if: github.ref == 'refs/heads/master' && env.run_covr == 'true' && runner.os == 'Linux'

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -192,6 +192,11 @@ jobs:
           cd preprocessCore
           R CMD INSTALL --configure-args="--disable-threading"  .
 
+      ## See https://github.com/rformassspectrometry/MsCoreUtils/pull/99#discussion_r984648126
+      - name: Install HDF5Array for unit tests
+        run: |
+          BiocManager::install("HDF5Array")
+
       - name: Install covr
         if: github.ref == 'refs/heads/master' && env.run_covr == 'true' && runner.os == 'Linux'
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,8 @@ Suggests:
     vsn,
     Matrix,
     preprocessCore,
-    missForest,
+    missForest
+Enhances:
     HDF5Array
 License: Artistic-2.0
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,8 @@ Suggests:
     vsn,
     Matrix,
     preprocessCore,
-    missForest
+    missForest,
+    HDF5Array
 License: Artistic-2.0
 Encoding: UTF-8
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MsCoreUtils
 Title: Core Utils for Mass Spectrometry Data
-Version: 1.9.1
+Version: 1.9.2
 Description: MsCoreUtils defines low-level functions for mass
     spectrometry data and is independent of any high-level data
     structures. These functions include mass spectra processing
@@ -65,4 +65,4 @@ BugReports: https://github.com/RforMassSpectrometry/MsCoreUtils/issues
 URL: https://github.com/RforMassSpectrometry/MsCoreUtils
 biocViews: Infrastructure, Proteomics, MassSpectrometry, Metabolomics
 Roxygen: list(markdown=TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## MsCoreUtils 1.9.2
 
+- feat: imputation is compatible with HDF5Matrix objects
 - feat: normalization is compatible with HDF5Matrix objects
 - feat: matrix aggregation is compatible with HDF5Matrix objects
 - fix+feat: aggregate_by_matrix now correctly handles missing data and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # MsCoreUtils 1.9
 
+## MsCoreUtils 1.9.2
+
+- (Nothing yet)
+
 ## MsCoreUtils 1.9.1
 
 - Random forest imputation (using `missForest`) is now available 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 ## MsCoreUtils 1.9.2
 
-- (Nothing yet)
+- feat: matrix aggregation is compatible with HDF5Matrix objects
+- fix+feat: aggregate_by_matrix now correctly handles missing data and
+  implements 'na.rm'
 
 ## MsCoreUtils 1.9.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## MsCoreUtils 1.9.2
 
+- feat: normalization is compatible with HDF5Matrix objects
 - feat: matrix aggregation is compatible with HDF5Matrix objects
 - fix+feat: aggregate_by_matrix now correctly handles missing data and
   implements 'na.rm'

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -8,9 +8,7 @@
 ##' method is defined by function `FUN`.
 ##'
 ##' Adjacency matrices are an elegant way to explicitly encode for
-##' shared peptides (see example below) during aggregation. Note
-##' however that missing values can't generally be ignore using `na.rm
-##' = TRUE`, as with vector-based aggregation (see examples below).
+##' shared peptides (see example below) during aggregation.
 ##'
 ##' @section Vector-based aggregation functions:
 ##'
@@ -43,6 +41,14 @@
 ##'    peptide intensities. Shared peptides are re-used multiple
 ##'    times.
 ##'
+##' @section Handling missing values:
+##' 
+##' By default, missing values in the quantitative data will propagate
+##' to the aggregated data. You can provide `na.rm = TRUE` to most 
+##' functions listed above to ignore missing values, except for 
+##' `robustSummary()` where you should supply `na.action = na.omit` 
+##' (see `?MASS::rlm`). 
+##' 
 ##' @family Quantitative feature aggregation
 ##'
 ##' @name aggregate

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -100,22 +100,17 @@
 ##'                             c("S1", "S2")))
 ##' x
 ##'
-##' ## simply use na.rm = TRUE to ignore missng values
+##' ## simply use na.rm = TRUE to ignore missing values
 ##' ## during the aggregation
 ##'
 ##' (k <- LETTERS[c(1, 1, 2)])
 ##' aggregate_by_vector(x, k, colSums)
 ##' aggregate_by_vector(x, k, colSums, na.rm = TRUE)
 ##'
-##'
-##' ## NAs are propagated during the matrix
-##' ## multiplication in the aggregation functon
 ##' (adj <- matrix(c(1, 1, 0, 0, 0, 1), ncol = 2,
 ##'                dimnames = list(paste0("Pep", 1:3),
-##'                                c("A", "B"))))
-##'
-##' aggregate_by_matrix(x, adj, colSumsMat)
-##' ## not implemented
-##' try(aggregate_by_matrix(x, adj, colSumsMat, na.rm = TRUE))
-##' colSumsMat
+##'                            c("A", "B"))))
+##' aggregate_by_matrix(x, adj, colSumsMat, na.rm = FALSE)
+##' aggregate_by_matrix(x, adj, colSumsMat, na.rm = TRUE)
+##' 
 NULL

--- a/R/aggregate_by_matrix.R
+++ b/R/aggregate_by_matrix.R
@@ -65,5 +65,8 @@ aggregate_by_matrix <- function(x, MAT, FUN, ...) {
     if (!is.null(colnames(x)) && !identical(colnames(x), colnames(res)))
         stop("The column names of 'x' have to be identical to the column names of 'res'!")
     colnames(res) <- colnames(x)
-    as.matrix(res)
+    if (inherits(x, "HDF5Matrix"))
+        res <- HDF5Array::writeHDF5Array(res, filepath = path(x),
+                                         with.dimnames = TRUE)
+    res
 }

--- a/R/aggregate_by_matrix.R
+++ b/R/aggregate_by_matrix.R
@@ -1,14 +1,39 @@
 #' @rdname aggregate
+#' 
+#' @param na.rm A `logical(1)` indicating whether the missing values 
+#'     (including NaN) should be omitted from the calculations or not.
+#'     Defaults to `FALSE`.
 #'
 #' @export
-colMeansMat <- function(x, MAT)
-  colSumsMat(x, MAT) / Matrix::colSums(MAT)
+colMeansMat <- function(x, MAT, na.rm = FALSE) {
+    if (na.rm) {
+        n <- Matrix::crossprod(MAT, !is.na(x))
+    } else {
+        n <- Matrix::colSums(MAT)
+    }
+    colSumsMat(x, MAT, na.rm = na.rm) / n
+}
+  
 
 #' @rdname aggregate
 #'
 #' @export
-colSumsMat <- function(x, MAT)
-  Matrix::crossprod(MAT, x)
+colSumsMat <- function(x, MAT, na.rm = FALSE) {
+    if (na.rm) {
+        x[is.na(x)] <- 0
+        res <- Matrix::crossprod(MAT, x)
+    } else {
+        ## Locate the missing data post-aggregation
+        xna <- Matrix::crossprod(MAT, is.na(x))
+        ## Avoid NAs to propagate to the whole column
+        x[is.na(x)] <- 0
+        res <- Matrix::crossprod(MAT, x)
+        ## Replace aggregated values that should be missing
+        res[xna == 1] <- NA
+    }
+    res
+}
+  
 
 
 ##' @param MAT An adjacency matrix that defines peptide-protein
@@ -27,8 +52,9 @@ colSumsMat <- function(x, MAT)
 ##'
 ##' @export
 aggregate_by_matrix <- function(x, MAT, FUN, ...) {
-    if (!is.matrix(x))
-        stop("'x' must be a matrix.")
+    if (!(is.matrix(x) | inherits(x, "HDF5Matrix")))
+        stop("'x' must be a matrix or an object that inherits from ",
+             "'HDF5Matrix'.")
     if (!is(MAT, "Matrix") && !is(MAT, "matrix"))
         stop("'MAT' must be a matrix.")
     if (!identical(nrow(MAT), nrow(x)))
@@ -39,5 +65,5 @@ aggregate_by_matrix <- function(x, MAT, FUN, ...) {
     if (!is.null(colnames(x)) && !identical(colnames(x), colnames(res)))
         stop("The column names of 'x' have to be identical to the column names of 'res'!")
     colnames(res) <- colnames(x)
-    res
+    as.matrix(res)
 }

--- a/R/aggregate_by_matrix.R
+++ b/R/aggregate_by_matrix.R
@@ -66,7 +66,8 @@ aggregate_by_matrix <- function(x, MAT, FUN, ...) {
         stop("The column names of 'x' have to be identical to the column names of 'res'!")
     colnames(res) <- colnames(x)
     if (inherits(x, "HDF5Matrix"))
-        res <- HDF5Array::writeHDF5Array(res, filepath = path(x),
+        res <- HDF5Array::writeHDF5Array(res, 
+                                         filepath = HDF5Array::path(x),
                                          with.dimnames = TRUE)
     res
 }

--- a/R/aggregate_by_vector.R
+++ b/R/aggregate_by_vector.R
@@ -171,7 +171,8 @@ aggregate_by_vector <- function(x, INDEX, FUN, ...) {
     rownames(res) <- nms
     colnames(res) <- colnames(x)
     if (inherits(x, "HDF5Matrix"))
-        res <- HDF5Array::writeHDF5Array(res, filepath = path(x),
+        res <- HDF5Array::writeHDF5Array(res, 
+                                         filepath = HDF5Array::path(x),
                                          with.dimnames = TRUE)
     res
 }

--- a/R/aggregate_by_vector.R
+++ b/R/aggregate_by_vector.R
@@ -33,10 +33,10 @@ robustSummary <- function(x, ...) {
 
     ## If there is only one 1 peptide for all samples return
     ## expression of that peptide
-    if (nrow(x) == 1L) return(x)
+    if (nrow(x) == 1L) return(as.matrix(x))
 
     ## remove missing values
-    p <- !is.na(x)
+    p <- as.vector(!is.na(x))
     expression <- x[p] ## expression becomes a vector
     sample <- rep(colnames(x), each = nrow(x))[p]
     feature <- rep(rownames(x), times = ncol(x))[p]
@@ -135,7 +135,7 @@ medianPolish <- function(x, verbose = FALSE, ...) {
 ##' m <- matrix(rnorm(30), nrow = 3)
 ##' colCounts(m)
 colCounts <- function(x, ...)
-    colSums(!is.na(x))
+    Matrix::colSums(!is.na(x))
 
 
 
@@ -155,8 +155,9 @@ colCounts <- function(x, ...)
 ##'
 ##' @export
 aggregate_by_vector <- function(x, INDEX, FUN, ...) {
-    if (!is.matrix(x))
-        stop("'x' must be a matrix.")
+    if (!(is.matrix(x) | inherits(x, "HDF5Matrix")))
+        stop("'x' must be a matrix or an object that inherits from ",
+             "'HDF5Matrix'.")
     if (!identical(length(INDEX), nrow(x)))
         stop("The length of 'INDEX' has to be identical to 'nrow(x).")
     FUN <- match.fun(FUN)

--- a/R/aggregate_by_vector.R
+++ b/R/aggregate_by_vector.R
@@ -139,7 +139,8 @@ colCounts <- function(x, ...)
 
 
 
-##' @param x A `matrix` of mode `numeric`.
+##' @param x A `matrix` of mode `numeric` or an `HDF5Matrix` object of
+##'     type `numeric`.
 ##'
 ##' @param INDEX A `vector` or `factor` of length `nrow(x)`.
 ##'
@@ -147,9 +148,10 @@ colCounts <- function(x, ...)
 ##'
 ##' @param ... Additional arguments passed to `FUN`.
 ##'
-##' @return [aggregate_by_vector()] returns a new `matrix` of
-##'     dimensions `length(INDEX)` and `ncol(x), with `dimnames` equal
-##'     to `colnames(x)` and `INDEX`.
+##' @return [aggregate_by_vector()] returns a new `matrix` (if `x` is
+##'     a `matrix`) or `HDF5Matrix` (if `x` is an `HDF5Matrix`)
+##'     of dimensions `length(INDEX)` and `ncol(x), with `dimnames` 
+##'     equal to `colnames(x)` and `INDEX`.
 ##'
 ##' @rdname aggregate
 ##'
@@ -168,5 +170,8 @@ aggregate_by_vector <- function(x, INDEX, FUN, ...) {
     res <- do.call(rbind, res)
     rownames(res) <- nms
     colnames(res) <- colnames(x)
+    if (inherits(x, "HDF5Matrix"))
+        res <- HDF5Array::writeHDF5Array(res, filepath = path(x),
+                                         with.dimnames = TRUE)
     res
 }

--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -52,8 +52,7 @@ factor) \code{INDEX} or an adjacency matrix \code{MAT}. The aggregation
 method is defined by function \code{FUN}.
 
 Adjacency matrices are an elegant way to explicitly encode for
-shared peptides (see example below) during aggregation. Note
-however that missing values can't generally be ignore using \code{na.rm = TRUE}, as with vector-based aggregation (see examples below).
+shared peptides (see example below) during aggregation.
 }
 \section{Vector-based aggregation functions}{
 
@@ -85,6 +84,16 @@ for each protein. Shared peptides are re-used multiple times.
 peptide intensities. Shared peptides are re-used multiple
 times.
 }
+}
+
+\section{Handling missing values}{
+
+
+By default, missing values in the quantitative data will propagate
+to the aggregated data. You can provide \code{na.rm = TRUE} to most
+functions listed above to ignore missing values, except for
+\code{robustSummary()} where you should supply \code{na.action = na.omit}
+(see \code{?MASS::rlm}).
 }
 
 \examples{

--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -9,9 +9,9 @@
 \alias{aggregate_by_matrix}
 \title{Aggreagate quantitative features}
 \usage{
-colMeansMat(x, MAT)
+colMeansMat(x, MAT, na.rm = FALSE)
 
-colSumsMat(x, MAT)
+colSumsMat(x, MAT, na.rm = FALSE)
 
 aggregate_by_matrix(x, MAT, FUN, ...)
 
@@ -25,6 +25,10 @@ relations with \code{nrow(MAT) == nrow(x)}: a non-missing/non-null
 value at position (i,j) indicates that peptide i belong to
 protein j. This matrix is tyically binary but can also contain
 weighted relations.}
+
+\item{na.rm}{A \code{logical(1)} indicating whether the missing values
+(including NaN) should be omitted from the calculations or not.
+Defaults to \code{FALSE}.}
 
 \item{FUN}{A \code{function} to be applied to the subsets of \code{x}.}
 
@@ -129,24 +133,15 @@ x <- matrix(c(NA, 2:6), ncol = 2,
                             c("S1", "S2")))
 x
 
-## simply use na.rm = TRUE to ignore missng values
+## simply use na.rm = TRUE to ignore missing values
 ## during the aggregation
 
 (k <- LETTERS[c(1, 1, 2)])
 aggregate_by_vector(x, k, colSums)
 aggregate_by_vector(x, k, colSums, na.rm = TRUE)
 
+aggregate_by_matrix(x, adj, colSumsMat, na.rm = TRUE)
 
-## NAs are propagated during the matrix
-## multiplication in the aggregation functon
-(adj <- matrix(c(1, 1, 0, 0, 0, 1), ncol = 2,
-               dimnames = list(paste0("Pep", 1:3),
-                               c("A", "B"))))
-
-aggregate_by_matrix(x, adj, colSumsMat)
-## not implemented
-try(aggregate_by_matrix(x, adj, colSumsMat, na.rm = TRUE))
-colSumsMat
 }
 \seealso{
 Other Quantitative feature aggregation: 

--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -140,6 +140,10 @@ x
 aggregate_by_vector(x, k, colSums)
 aggregate_by_vector(x, k, colSums, na.rm = TRUE)
 
+(adj <- matrix(c(1, 1, 0, 0, 0, 1), ncol = 2,
+               dimnames = list(paste0("Pep", 1:3),
+                           c("A", "B"))))
+aggregate_by_matrix(x, adj, colSumsMat, na.rm = FALSE)
 aggregate_by_matrix(x, adj, colSumsMat, na.rm = TRUE)
 
 }

--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -18,7 +18,8 @@ aggregate_by_matrix(x, MAT, FUN, ...)
 aggregate_by_vector(x, INDEX, FUN, ...)
 }
 \arguments{
-\item{x}{A \code{matrix} of mode \code{numeric}.}
+\item{x}{A \code{matrix} of mode \code{numeric} or an \code{HDF5Matrix} object of
+type \code{numeric}.}
 
 \item{MAT}{An adjacency matrix that defines peptide-protein
 relations with \code{nrow(MAT) == nrow(x)}: a non-missing/non-null
@@ -40,8 +41,9 @@ Defaults to \code{FALSE}.}
 \code{\link[=aggregate_by_matrix]{aggregate_by_matrix()}} returns a \code{matrix} (or \code{Matrix})
 of dimensions \code{ncol(MAT)} and \verb{ncol(x), with }dimnames\verb{equal to}colnames(x)\code{and}rownames(MAT)`.
 
-\code{\link[=aggregate_by_vector]{aggregate_by_vector()}} returns a new \code{matrix} of
-dimensions \code{length(INDEX)} and \verb{ncol(x), with }dimnames\verb{equal to}colnames(x)\code{and}INDEX`.
+\code{\link[=aggregate_by_vector]{aggregate_by_vector()}} returns a new \code{matrix} (if \code{x} is
+a \code{matrix}) or \code{HDF5Matrix} (if \code{x} is an \code{HDF5Matrix})
+of dimensions \code{length(INDEX)} and \verb{ncol(x), with }dimnames\verb{ equal to}colnames(x)\code{and}INDEX`.
 }
 \description{
 These functions take a matrix of quantitative features \code{x} and

--- a/man/imputation.Rd
+++ b/man/imputation.Rd
@@ -40,7 +40,7 @@ impute_with(x, val)
 impute_fun(x, FUN, ...)
 }
 \arguments{
-\item{x}{A matrix with missing values to be imputed.}
+\item{x}{A matrix or an \code{HDF5Matrix} object to be imputed.}
 
 \item{method}{\code{character(1)} defining the imputation method. See
 \code{imputeMethods()} for available ones.}
@@ -67,6 +67,9 @@ is \code{mixed}.}
 random. See \code{method} above.}
 
 \item{val}{\code{numeric(1)} used to replace all missing values.}
+}
+\value{
+A matrix of same class as \code{x} with dimensions \code{dim(x)}.
 }
 \description{
 The \code{impute_matrix} function performs data imputation on \code{matrix}
@@ -106,7 +109,8 @@ Currently, the following imputation methods are available.
 \item \emph{MLE}: Maximum likelihood-based imputation method using the EM
 algorithm. Implemented in the \code{norm::imp.norm()}. function. See
 \code{\link[norm:imp.norm]{norm::imp.norm()}} for details and additional parameters. Note
-that here, \code{...} are passed to the [norm::em.norm()\verb{function, rather to the actual imputation function}imp.norm`.
+that here, \code{...} are passed to the \code{\link[norm:em.norm]{norm::em.norm()}} function,
+rather to the actual imputation function \code{imp.norm}.
 \item \emph{bpca}: Bayesian missing value imputation are available, as
 implemented in the \code{pcaMethods::pca()} function. See
 \code{\link[pcaMethods:pca]{pcaMethods::pca()}} for details and additional parameters.

--- a/man/normalize.Rd
+++ b/man/normalize.Rd
@@ -10,7 +10,7 @@ normalizeMethods()
 normalize_matrix(x, method, ...)
 }
 \arguments{
-\item{x}{A matrix to be normalised.}
+\item{x}{A matrix or an \code{HDF5Matrix} object to be normalised.}
 
 \item{method}{\code{character(1)} defining the normalisation
 method. See \code{normalizeMethods()} for available ones.}
@@ -19,7 +19,7 @@ method. See \code{normalizeMethods()} for available ones.}
 function.}
 }
 \value{
-A normalised matrix of dimensions \code{dim(x)}.
+A matrix of same class as \code{x} with dimensions \code{dim(x)}.
 }
 \description{
 Function to normalise a matrix of quantitative omics data. The

--- a/tests/testthat/test_aggregate.R
+++ b/tests/testthat/test_aggregate.R
@@ -96,12 +96,16 @@ test_that("aggregation: aggregate_by_vector", {
     expect_equal(x2_robust_expected[same_row_names, ],
                  aggregate_by_vector(x, k_fact2, robustSummary)[same_row_names, ])
     ## Test HDF5Matrix compatibility
+    hdf5out <- aggregate_by_vector(xhdf5, k_char, robustSummary)
+    expect_true(inherits(hdf5out, "HDF5Matrix"))
     expect_equal(x2_robust_expected[same_row_names, ],
-                 aggregate_by_vector(xhdf5, k_char, robustSummary)[same_row_names, ])
+                 as.matrix(hdf5out)[same_row_names, ])
+    hdf5out <- aggregate_by_vector(xhdf5, k_fact, robustSummary)
     expect_equal(x2_robust_expected[same_row_names, ],
-                 aggregate_by_vector(xhdf5, k_fact, robustSummary)[same_row_names, ])
+                 as.matrix(hdf5out)[same_row_names, ])
+    hdf5out <- aggregate_by_vector(xhdf5, k_fact2, robustSummary)
     expect_equal(x2_robust_expected[same_row_names, ],
-                 aggregate_by_vector(xhdf5, k_fact2, robustSummary)[same_row_names, ])
+                 as.matrix(hdf5out)[same_row_names, ])
     ## aggregate: medianPolish
     x2_medpolish_expected <-
         structure(c(3.36717083720277, 3.63886529932001,
@@ -122,13 +126,16 @@ test_that("aggregation: aggregate_by_vector", {
     expect_equal(x2_medpolish_expected[same_row_names, ],
                  aggregate_by_vector(x, k_fact2, medianPolish)[same_row_names, ])
     ## Test HDF5Matrix compatibility
+    hdf5out <- aggregate_by_vector(xhdf5, k_char, medianPolish)
+    expect_true(inherits(hdf5out, "HDF5Matrix"))
     expect_equal(x2_medpolish_expected[same_row_names, ],
-                 aggregate_by_vector(xhdf5, k_char, medianPolish)[same_row_names, ])
+                 as.matrix(hdf5out)[same_row_names, ])
+    hdf5out <- aggregate_by_vector(xhdf5, k_fact, medianPolish)
     expect_equal(x2_medpolish_expected[same_row_names, ],
-                 aggregate_by_vector(x, k_fact, medianPolish)[same_row_names, ])
+                 as.matrix(hdf5out)[same_row_names, ])
+    hdf5out <- aggregate_by_vector(xhdf5, k_fact2, medianPolish)
     expect_equal(x2_medpolish_expected[same_row_names, ],
-                 aggregate_by_vector(x, k_fact2, medianPolish)[same_row_names, ])
-    
+                 as.matrix(hdf5out)[same_row_names, ])
     ## aggregate: sum
     x2_sum_expected <-
         structure(c(9.70155804007753, 9.75542561310774,
@@ -149,13 +156,16 @@ test_that("aggregation: aggregate_by_vector", {
     expect_equal(x2_sum_expected[same_row_names, ],
                  aggregate_by_vector(x, k_fact2, colSums)[same_row_names, ])
     ## Test HDF5Matrix compatibility
+    hdf5out <- aggregate_by_vector(xhdf5, k_char, Matrix::colSums)
+    expect_true(inherits(hdf5out, "HDF5Matrix"))
     expect_equal(x2_sum_expected[same_row_names, ],
-                 aggregate_by_vector(xhdf5, k_char, Matrix::colSums)[same_row_names, ])
+                 as.matrix(hdf5out)[same_row_names, ])
+    hdf5out <- aggregate_by_vector(xhdf5, k_fact, Matrix::colSums)
     expect_equal(x2_sum_expected[same_row_names, ],
-                 aggregate_by_vector(xhdf5, k_fact, Matrix::colSums)[same_row_names, ])
+                 as.matrix(hdf5out)[same_row_names, ])
+    hdf5out <- aggregate_by_vector(xhdf5, k_fact2, Matrix::colSums)
     expect_equal(x2_sum_expected[same_row_names, ],
-                 aggregate_by_vector(xhdf5, k_fact2, Matrix::colSums)[same_row_names, ])
-    unlink(tmpf, recursive = TRUE)
+                 as.matrix(hdf5out)[same_row_names, ])
 })
 
 
@@ -164,7 +174,7 @@ test_that("aggregation: colCounts", {
     m <- matrix(c(1, NA, 2, 3, NA, NA, 4, 5, 6),
                 nrow = 3)
     expect_identical(colCounts(m), c(2, 1, 3))
-    ## Data in HDF5
+    ## Test HDF5Matrix compatibility
     tmpf <- paste0(tempdir(), "/mhdf5")
     mhdf5 <- writeHDF5Array(m, tmpf, with.dimnames = TRUE)
     expect_identical(colCounts(mhdf5), c(2, 1, 3))
@@ -215,13 +225,15 @@ test_that("aggregate_by_matix works", {
     am <- aggregate_by_matrix(x, adj, colSumsMat)
     amhdf5 <- aggregate_by_matrix(xhdf5, adj, colSumsMat)
     expect_identical(av, am)
-    expect_identical(am, amhdf5)
+    expect_true(inherits(amhdf5, "HDF5Matrix"))
+    expect_identical(am, as.matrix(amhdf5))
     ## aggregation by mean
     av <- aggregate_by_vector(x, k, colMeans)
     am <- aggregate_by_matrix(x, adj, colMeansMat)
     amhdf5 <- aggregate_by_matrix(xhdf5, adj, colMeansMat)
     expect_identical(av, am)
-    expect_identical(am, amhdf5)
+    expect_true(inherits(amhdf5, "HDF5Matrix"))
+    expect_identical(am, as.matrix(amhdf5))
     
     unlink(tmpf)
 })
@@ -253,25 +265,28 @@ test_that("aggregate_by_matix works with NAs", {
     am <- aggregate_by_matrix(x, adj, colSumsMat)
     amhdf5 <- aggregate_by_matrix(xhdf5, adj, colSumsMat)
     expect_identical(av, am)
-    expect_identical(am, amhdf5)
+    expect_identical(am, as.matrix(amhdf5))
     ## aggregation by mean, na.rm = FALSE
     av <- aggregate_by_vector(x, k, colMeans)
     am <- aggregate_by_matrix(x, adj, colMeansMat)
     amhdf5 <- aggregate_by_matrix(xhdf5, adj, colMeansMat)
+    expect_true(inherits(amhdf5, "HDF5Matrix"))
     expect_identical(av, am)
-    expect_identical(am, amhdf5)
+    expect_identical(am, as.matrix(amhdf5))
     ## aggregation by sum, na.rm = TRUE
     av <- aggregate_by_vector(x, k, colSums, na.rm = TRUE)
     am <- aggregate_by_matrix(x, adj, colSumsMat, na.rm = TRUE)
     amhdf5 <- aggregate_by_matrix(xhdf5, adj, colSumsMat, na.rm = TRUE)
+    expect_true(inherits(amhdf5, "HDF5Matrix"))
     expect_identical(av, am)
-    expect_identical(am, amhdf5)
+    expect_identical(am, as.matrix(amhdf5))
     ## aggregation by mean, na.rm = TRUE
     av <- aggregate_by_vector(x, k, colMeans, na.rm = TRUE)
     am <- aggregate_by_matrix(x, adj, colMeansMat, na.rm = TRUE)
     amhdf5 <- aggregate_by_matrix(xhdf5, adj, colMeansMat, na.rm = TRUE)
+    expect_true(inherits(amhdf5, "HDF5Matrix"))
     expect_identical(av, am)
-    expect_identical(am, amhdf5)
+    expect_identical(am, as.matrix(amhdf5))
     
     unlink(amhdf5)
 })

--- a/tests/testthat/test_aggregate.R
+++ b/tests/testthat/test_aggregate.R
@@ -306,7 +306,7 @@ test_that("aggregate_by_matrix works with NAs", {
         amhdf5 <- aggregate_by_matrix(xhdf5, adj, colMeansMat, na.rm = TRUE)
         expect_identical(am4, as.matrix(amhdf5))
         ## Remove file
-        unlink(amhdf5)
+        unlink(tmpf)
     }
 })
 

--- a/tests/testthat/test_aggregate.R
+++ b/tests/testthat/test_aggregate.R
@@ -210,7 +210,7 @@ test_that("aggregation: colCounts", {
 })
 
 
-test_that("aggregate_by_matix works", {
+test_that("aggregate_by_matrix works", {
     ## numerical example taken from ?stats::medpolish
     x <- rbind(c(14,15,14),
                c( 7, 4, 7),
@@ -254,7 +254,7 @@ test_that("aggregate_by_matix works", {
 })
 
 
-test_that("aggregate_by_matix works with NAs", {
+test_that("aggregate_by_matrix works with NAs", {
     ## numerical example taken from ?stats::medpolish
     x <- rbind(c(14,15,14),
                c( 7, 4, 7),

--- a/tests/testthat/test_aggregate.R
+++ b/tests/testthat/test_aggregate.R
@@ -1,4 +1,3 @@
-library(HDF5Array)
 
 test_that("aggregation: medianPolish", {
     ## numerical example taken from ?stats::medpolish
@@ -65,9 +64,6 @@ test_that("aggregation: aggregate_by_vector", {
                                       "X53", "X55"),
                                     c("iTRAQ4.114", "iTRAQ4.115",
                                       "iTRAQ4.116", "iTRAQ4.117")))
-    ## Data in HDF5
-    tmpf <- paste0(tempdir(), "/xhdf5")
-    xhdf5 <- writeHDF5Array(x, tmpf, with.dimnames = TRUE)
     ## Different ways to provide INDEX
     k_char <- c("B", "E", "X", "E", "B", "B", "E")
     k_fact <- factor(k_char)
@@ -95,17 +91,6 @@ test_that("aggregation: aggregate_by_vector", {
                  aggregate_by_vector(x, k_fact, robustSummary)[same_row_names, ])
     expect_equal(x2_robust_expected[same_row_names, ],
                  aggregate_by_vector(x, k_fact2, robustSummary)[same_row_names, ])
-    ## Test HDF5Matrix compatibility
-    hdf5out <- aggregate_by_vector(xhdf5, k_char, robustSummary)
-    expect_true(inherits(hdf5out, "HDF5Matrix"))
-    expect_equal(x2_robust_expected[same_row_names, ],
-                 as.matrix(hdf5out)[same_row_names, ])
-    hdf5out <- aggregate_by_vector(xhdf5, k_fact, robustSummary)
-    expect_equal(x2_robust_expected[same_row_names, ],
-                 as.matrix(hdf5out)[same_row_names, ])
-    hdf5out <- aggregate_by_vector(xhdf5, k_fact2, robustSummary)
-    expect_equal(x2_robust_expected[same_row_names, ],
-                 as.matrix(hdf5out)[same_row_names, ])
     ## aggregate: medianPolish
     x2_medpolish_expected <-
         structure(c(3.36717083720277, 3.63886529932001,
@@ -125,17 +110,6 @@ test_that("aggregation: aggregate_by_vector", {
                  aggregate_by_vector(x, k_fact, medianPolish)[same_row_names, ])
     expect_equal(x2_medpolish_expected[same_row_names, ],
                  aggregate_by_vector(x, k_fact2, medianPolish)[same_row_names, ])
-    ## Test HDF5Matrix compatibility
-    hdf5out <- aggregate_by_vector(xhdf5, k_char, medianPolish)
-    expect_true(inherits(hdf5out, "HDF5Matrix"))
-    expect_equal(x2_medpolish_expected[same_row_names, ],
-                 as.matrix(hdf5out)[same_row_names, ])
-    hdf5out <- aggregate_by_vector(xhdf5, k_fact, medianPolish)
-    expect_equal(x2_medpolish_expected[same_row_names, ],
-                 as.matrix(hdf5out)[same_row_names, ])
-    hdf5out <- aggregate_by_vector(xhdf5, k_fact2, medianPolish)
-    expect_equal(x2_medpolish_expected[same_row_names, ],
-                 as.matrix(hdf5out)[same_row_names, ])
     ## aggregate: sum
     x2_sum_expected <-
         structure(c(9.70155804007753, 9.75542561310774,
@@ -155,17 +129,48 @@ test_that("aggregation: aggregate_by_vector", {
                  aggregate_by_vector(x, k_fact, colSums)[same_row_names, ])
     expect_equal(x2_sum_expected[same_row_names, ],
                  aggregate_by_vector(x, k_fact2, colSums)[same_row_names, ])
+    
     ## Test HDF5Matrix compatibility
-    hdf5out <- aggregate_by_vector(xhdf5, k_char, Matrix::colSums)
-    expect_true(inherits(hdf5out, "HDF5Matrix"))
-    expect_equal(x2_sum_expected[same_row_names, ],
-                 as.matrix(hdf5out)[same_row_names, ])
-    hdf5out <- aggregate_by_vector(xhdf5, k_fact, Matrix::colSums)
-    expect_equal(x2_sum_expected[same_row_names, ],
-                 as.matrix(hdf5out)[same_row_names, ])
-    hdf5out <- aggregate_by_vector(xhdf5, k_fact2, Matrix::colSums)
-    expect_equal(x2_sum_expected[same_row_names, ],
-                 as.matrix(hdf5out)[same_row_names, ])
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Data in HDF5
+        tmpf <- paste0(tempdir(), "/xhdf5")
+        xhdf5 <- HDF5Array::writeHDF5Array(x, tmpf, with.dimnames = TRUE)
+        ## robustSummary
+        hdf5out <- aggregate_by_vector(xhdf5, k_char, robustSummary)
+        expect_true(inherits(hdf5out, "HDF5Matrix"))
+        expect_equal(x2_robust_expected[same_row_names, ],
+                     as.matrix(hdf5out)[same_row_names, ])
+        hdf5out <- aggregate_by_vector(xhdf5, k_fact, robustSummary)
+        expect_equal(x2_robust_expected[same_row_names, ],
+                     as.matrix(hdf5out)[same_row_names, ])
+        hdf5out <- aggregate_by_vector(xhdf5, k_fact2, robustSummary)
+        expect_equal(x2_robust_expected[same_row_names, ],
+                     as.matrix(hdf5out)[same_row_names, ])
+        ## medianPolish
+        hdf5out <- aggregate_by_vector(xhdf5, k_char, medianPolish)
+        expect_true(inherits(hdf5out, "HDF5Matrix"))
+        expect_equal(x2_medpolish_expected[same_row_names, ],
+                     as.matrix(hdf5out)[same_row_names, ])
+        hdf5out <- aggregate_by_vector(xhdf5, k_fact, medianPolish)
+        expect_equal(x2_medpolish_expected[same_row_names, ],
+                     as.matrix(hdf5out)[same_row_names, ])
+        hdf5out <- aggregate_by_vector(xhdf5, k_fact2, medianPolish)
+        expect_equal(x2_medpolish_expected[same_row_names, ],
+                     as.matrix(hdf5out)[same_row_names, ])
+        ## Matrix::colSums
+        hdf5out <- aggregate_by_vector(xhdf5, k_char, Matrix::colSums)
+        expect_true(inherits(hdf5out, "HDF5Matrix"))
+        expect_equal(x2_sum_expected[same_row_names, ],
+                     as.matrix(hdf5out)[same_row_names, ])
+        hdf5out <- aggregate_by_vector(xhdf5, k_fact, Matrix::colSums)
+        expect_equal(x2_sum_expected[same_row_names, ],
+                     as.matrix(hdf5out)[same_row_names, ])
+        hdf5out <- aggregate_by_vector(xhdf5, k_fact2, Matrix::colSums)
+        expect_equal(x2_sum_expected[same_row_names, ],
+                     as.matrix(hdf5out)[same_row_names, ])
+        ## Remove file
+        unlink(tmpf)
+    }
 })
 
 
@@ -174,11 +179,6 @@ test_that("aggregation: colCounts", {
     m <- matrix(c(1, NA, 2, 3, NA, NA, 4, 5, 6),
                 nrow = 3)
     expect_identical(colCounts(m), c(2, 1, 3))
-    ## Test HDF5Matrix compatibility
-    tmpf <- paste0(tempdir(), "/mhdf5")
-    mhdf5 <- writeHDF5Array(m, tmpf, with.dimnames = TRUE)
-    expect_identical(colCounts(mhdf5), c(2, 1, 3))
-    unlink(tmpf)
     ## No NAs
     m <- matrix(rnorm(30), nrow = 3)
     expect_identical(colCounts(m), rep(3, 10))
@@ -196,8 +196,18 @@ test_that("aggregation: colCounts", {
     ## NA and Inf
     m[2,2] <- Inf
     expect_identical(colCounts(m), c(4, rep(5, 4)))
+    
+    ## Test HDF5Matrix compatibility
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Test HDF5Matrix compatibility
+        tmpf <- paste0(tempdir(), "/mhdf5")
+        m <- matrix(c(1, NA, 2, 3, NA, NA, 4, 5, 6),
+                    nrow = 3)
+        mhdf5 <- HDF5Array::writeHDF5Array(m, tmpf, with.dimnames = TRUE)
+        expect_identical(colCounts(mhdf5), c(2, 1, 3))
+        unlink(tmpf)
+    }
 })
-
 
 
 test_that("aggregate_by_matix works", {
@@ -209,9 +219,6 @@ test_that("aggregate_by_matix works", {
                c( 0, 2, 0))
     colnames(x) <- paste0("S", 1:3)
     rownames(x) <- paste0("pep", 1:5)
-    ## Data in HDF5
-    tmpf <- paste0(tempdir(), "/mhdf5")
-    xhdf5 <- writeHDF5Array(x, tmpf, with.dimnames = TRUE)
     ## aggregation index
     k <- paste0("Prot", rep(1:2, c(2, 3)))
     ## adjacency matrix
@@ -221,21 +228,29 @@ test_that("aggregate_by_matix works", {
     rownames(adj) <- rownames(x)
     colnames(adj) <- unique(k)
     ## aggregation by sum
-    av <- aggregate_by_vector(x, k, colSums)
-    am <- aggregate_by_matrix(x, adj, colSumsMat)
-    amhdf5 <- aggregate_by_matrix(xhdf5, adj, colSumsMat)
-    expect_identical(av, am)
-    expect_true(inherits(amhdf5, "HDF5Matrix"))
-    expect_identical(am, as.matrix(amhdf5))
+    av1 <- aggregate_by_vector(x, k, colSums)
+    am1 <- aggregate_by_matrix(x, adj, colSumsMat)
+    expect_identical(av1, am1)
     ## aggregation by mean
-    av <- aggregate_by_vector(x, k, colMeans)
-    am <- aggregate_by_matrix(x, adj, colMeansMat)
-    amhdf5 <- aggregate_by_matrix(xhdf5, adj, colMeansMat)
-    expect_identical(av, am)
-    expect_true(inherits(amhdf5, "HDF5Matrix"))
-    expect_identical(am, as.matrix(amhdf5))
-    
-    unlink(tmpf)
+    av2 <- aggregate_by_vector(x, k, colMeans)
+    am2 <- aggregate_by_matrix(x, adj, colMeansMat)
+    expect_identical(av2, am2)
+    ## Test HDF5Matrix compatibility
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Data in HDF5
+        tmpf <- paste0(tempdir(), "/mhdf5")
+        xhdf5 <- HDF5Array::writeHDF5Array(x, tmpf, with.dimnames = TRUE)
+        ## colSumsMat
+        amhdf5 <- aggregate_by_matrix(xhdf5, adj, colSumsMat)
+        expect_true(inherits(amhdf5, "HDF5Matrix"))
+        expect_identical(am1, as.matrix(amhdf5))
+        ## colMeansMat
+        amhdf5 <- aggregate_by_matrix(xhdf5, adj, colMeansMat)
+        expect_true(inherits(amhdf5, "HDF5Matrix"))
+        expect_identical(am2, as.matrix(amhdf5))
+        ## Remove file
+        unlink(tmpf)
+    }
 })
 
 
@@ -249,9 +264,6 @@ test_that("aggregate_by_matix works with NAs", {
     colnames(x) <- paste0("S", 1:3)
     rownames(x) <- paste0("pep", 1:5)
     x[1, 1] <- x[4, 2] <- NA
-    ## Data in HDF5
-    tmpf <- paste0(tempdir(), "/mhdf5")
-    xhdf5 <- writeHDF5Array(x, tmpf, with.dimnames = TRUE)
     ## aggregation index
     k <- paste0("Prot", rep(1:2, c(2, 3)))
     ## adjacency matrix
@@ -261,33 +273,40 @@ test_that("aggregate_by_matix works with NAs", {
     rownames(adj) <- rownames(x)
     colnames(adj) <- unique(k)
     ## aggregation by sum, na.rm = FALSE
-    av <- aggregate_by_vector(x, k, colSums)
-    am <- aggregate_by_matrix(x, adj, colSumsMat)
-    amhdf5 <- aggregate_by_matrix(xhdf5, adj, colSumsMat)
-    expect_identical(av, am)
-    expect_identical(am, as.matrix(amhdf5))
+    av1 <- aggregate_by_vector(x, k, colSums)
+    am1 <- aggregate_by_matrix(x, adj, colSumsMat)
+    expect_identical(av1, am1)
     ## aggregation by mean, na.rm = FALSE
-    av <- aggregate_by_vector(x, k, colMeans)
-    am <- aggregate_by_matrix(x, adj, colMeansMat)
-    amhdf5 <- aggregate_by_matrix(xhdf5, adj, colMeansMat)
-    expect_true(inherits(amhdf5, "HDF5Matrix"))
-    expect_identical(av, am)
-    expect_identical(am, as.matrix(amhdf5))
+    av2 <- aggregate_by_vector(x, k, colMeans)
+    am2 <- aggregate_by_matrix(x, adj, colMeansMat)
+    expect_identical(av2, am2)
     ## aggregation by sum, na.rm = TRUE
-    av <- aggregate_by_vector(x, k, colSums, na.rm = TRUE)
-    am <- aggregate_by_matrix(x, adj, colSumsMat, na.rm = TRUE)
-    amhdf5 <- aggregate_by_matrix(xhdf5, adj, colSumsMat, na.rm = TRUE)
-    expect_true(inherits(amhdf5, "HDF5Matrix"))
-    expect_identical(av, am)
-    expect_identical(am, as.matrix(amhdf5))
+    av3 <- aggregate_by_vector(x, k, colSums, na.rm = TRUE)
+    am3 <- aggregate_by_matrix(x, adj, colSumsMat, na.rm = TRUE)
+    expect_identical(av3, am3)
     ## aggregation by mean, na.rm = TRUE
-    av <- aggregate_by_vector(x, k, colMeans, na.rm = TRUE)
-    am <- aggregate_by_matrix(x, adj, colMeansMat, na.rm = TRUE)
-    amhdf5 <- aggregate_by_matrix(xhdf5, adj, colMeansMat, na.rm = TRUE)
-    expect_true(inherits(amhdf5, "HDF5Matrix"))
-    expect_identical(av, am)
-    expect_identical(am, as.matrix(amhdf5))
-    
-    unlink(amhdf5)
+    av4 <- aggregate_by_vector(x, k, colMeans, na.rm = TRUE)
+    am4 <- aggregate_by_matrix(x, adj, colMeansMat, na.rm = TRUE)
+    expect_identical(av4, am4)
+    ## Test HDF5Matrix compatibility
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Data in HDF5
+        tmpf <- paste0(tempdir(), "/mhdf5")
+        xhdf5 <- HDF5Array::writeHDF5Array(x, tmpf, with.dimnames = TRUE)
+        ## aggregation by sum, na.rm = FALSE
+        amhdf5 <- aggregate_by_matrix(xhdf5, adj, colSumsMat)
+        expect_identical(am1, as.matrix(amhdf5))
+        ## aggregation by mean, na.rm = FALSE
+        amhdf5 <- aggregate_by_matrix(xhdf5, adj, colMeansMat)
+        expect_identical(am2, as.matrix(amhdf5))
+        ## aggregation by sum, na.rm = TRUE
+        amhdf5 <- aggregate_by_matrix(xhdf5, adj, colSumsMat, na.rm = TRUE)
+        expect_identical(am3, as.matrix(amhdf5))
+        ## aggregation by mean, na.rm = TRUE
+        amhdf5 <- aggregate_by_matrix(xhdf5, adj, colMeansMat, na.rm = TRUE)
+        expect_identical(am4, as.matrix(amhdf5))
+        ## Remove file
+        unlink(amhdf5)
+    }
 })
 

--- a/tests/testthat/test_imputation.R
+++ b/tests/testthat/test_imputation.R
@@ -5,7 +5,12 @@ test_that("all imputation methods", {
     m <- m[m != "with"]  ## see below
     m <- m[m != "nbavg"] ## see next test
     for (.m in m) {
-        xx <- impute_matrix(x, method = .m)
+        if (.m == "knn") {
+            expect_warning(xx <- impute_matrix(x, method = .m),
+                           regexp = "more than.*entries missing")
+        } else {
+            xx <- impute_matrix(x, method = .m)  
+        }
         expect_false(any(is.na(xx)))
     }
     expect_error(impute_matrix(x, method = "mixed",
@@ -30,17 +35,70 @@ test_that("all imputation methods", {
                         mnar = "min",
                         mar = "knn")
     expect_false(any(is.na(mx)))
+    ## Test HDF5Matrix compatibility
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Data in HDF5
+        tmpf <- paste0(tempdir(), "/mhdf5")
+        xhdf5 <- HDF5Array::writeHDF5Array(x, tmpf, with.dimnames = TRUE)
+        for (.m in m) {
+            set.seed(1234)
+            if (.m == "knn") {
+                expect_warning(xxhdf5 <- impute_matrix(xhdf5, method = .m),
+                               regexp = "more than.*entries missing")
+            } else {
+                xxhdf5 <- impute_matrix(xhdf5, method = .m)
+            }
+            expect_true(inherits(xxhdf5, "HDF5Matrix"))
+            if (.m != "MLE") { ## MLE is non-deterministic (apparently)
+                set.seed(1234)
+                if (.m == "knn") {
+                    expect_warning(xx <- impute_matrix(x, method = .m),
+                                   regexp = "more than.*entries missing")
+                } else {
+                    xx <- impute_matrix(x, method = .m)  
+                }
+                expect_equal(as.matrix(xxhdf5), xx)
+            }
+        }
+        ## Remove file
+        unlink(tmpf)
+    }
 })
 
 test_that("none method", {
     xx <- impute_matrix(x, method = "none")
     expect_identical(x, xx)
+    ## Test HDF5Matrix compatibility
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Data in HDF5
+        tmpf <- paste0(tempdir(), "/mhdf5")
+        xhdf5 <- HDF5Array::writeHDF5Array(x, tmpf, with.dimnames = TRUE)
+        xxhdf5 <- impute_matrix(xhdf5, method = "none")
+        expect_true(inherits(xxhdf5, "HDF5Matrix"))
+        expect_equal(as.matrix(xxhdf5), xx)
+        ## Remove file
+        unlink(tmpf)
+    }
 })
 
 test_that("zero and with method", {
     x1 <- impute_matrix(x, method = "with", val = 0)
     x2 <- impute_matrix(x, method = "zero")
     expect_identical(x1, x2)
+    ## Test HDF5Matrix compatibility
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Data in HDF5
+        tmpf <- paste0(tempdir(), "/mhdf5")
+        xhdf5 <- HDF5Array::writeHDF5Array(x, tmpf, with.dimnames = TRUE)
+        xxhdf5 <- impute_matrix(xhdf5, method = "with", val = 0)
+        expect_true(inherits(xxhdf5, "HDF5Matrix"))
+        expect_equal(as.matrix(xxhdf5), x1)
+        xxhdf5 <- impute_matrix(xhdf5, method = "zero")
+        expect_true(inherits(xxhdf5, "HDF5Matrix"))
+        expect_equal(as.matrix(xxhdf5), x2)
+        ## Remove file
+        unlink(tmpf)
+    }
 })
 
 test_that("nbavg methods", {
@@ -76,6 +134,17 @@ test_that("nbavg methods", {
     expect_true(all(is.na(xx[3, 3:4])))
     expect_true(xx[5, 2] == 10)
     expect_true(xx[4, 3] == 14)
+    ## Test HDF5Matrix compatibility
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Data in HDF5
+        tmpf <- paste0(tempdir(), "/mhdf5")
+        xhdf5 <- HDF5Array::writeHDF5Array(x2, tmpf, with.dimnames = TRUE)
+        xxhdf5 <- impute_matrix(xhdf5, method = "nbavg", k = 0)
+        expect_true(inherits(xxhdf5, "HDF5Matrix"))
+        expect_equal(as.matrix(xxhdf5), xx)
+        ## Remove file
+        unlink(tmpf)
+    }
 })
 
 
@@ -93,9 +162,21 @@ test_that("impute: mandatory method", {
 })
 
 test_that("impute: absence of missing values", {
-    x_imp <- impute_matrix(x, method = "knn")
+    expect_warning(x_imp <- impute_matrix(x, method = "knn"),
+                   regexp = "more than.*entries missing")
     x_imp_2 <- impute_matrix(x_imp, method = "knn")
     expect_identical(x_imp, x_imp_2)
+    ## Test HDF5Matrix compatibility
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Data in HDF5
+        tmpf <- paste0(tempdir(), "/mhdf5")
+        xhdf5 <- HDF5Array::writeHDF5Array(x_imp, tmpf, with.dimnames = TRUE)
+        xxhdf5 <- impute_matrix(xhdf5, method = "knn")
+        expect_true(inherits(xxhdf5, "HDF5Matrix"))
+        expect_equal(as.matrix(xxhdf5), x_imp)
+        ## Remove file
+        unlink(tmpf)
+    }
 })
 
 test_that("impute: user-provided function", {
@@ -116,4 +197,15 @@ test_that("impute: user-provided function", {
     x2[1, 1] <- 1000
     expect_equal(x2, x_imp)
     expect_equal(x2, x_imp2)
+    ## Test HDF5Matrix compatibility
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Data in HDF5
+        tmpf <- paste0(tempdir(), "/mhdf5")
+        xhdf5 <- HDF5Array::writeHDF5Array(x3, tmpf, with.dimnames = TRUE)
+        xxhdf5 <- impute_matrix(xhdf5, FUN = user_fun, val = 1000)
+        expect_true(inherits(xxhdf5, "HDF5Matrix"))
+        expect_equal(as.matrix(xxhdf5), x_imp)
+        ## Remove file
+        unlink(tmpf)
+    }
 })

--- a/tests/testthat/test_normalize.R
+++ b/tests/testthat/test_normalize.R
@@ -3,6 +3,20 @@ test_that("function: all normalize methods", {
         x_norm <- normalize_matrix(x, method = .method)
         expect_identical(dim(x_norm), dim(x))
     }
+    ## Test HDF5Matrix compatibility
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Data in HDF5
+        tmpf <- paste0(tempdir(), "/mhdf5")
+        xhdf5 <- HDF5Array::writeHDF5Array(x, tmpf, with.dimnames = TRUE)
+        for (.method in normalizeMethods()) {
+            x_norm <- normalize_matrix(x, method = .method)
+            x_normhdf5 <- normalize_matrix(xhdf5, method = .method)
+            expect_true(inherits(x_normhdf5, "HDF5Matrix"))
+            expect_identical(as.matrix(x_normhdf5), x_norm)
+        }  
+        ## Remove file
+        unlink(tmpf)
+    }
 })
 
 test_that("function: center.mean and center.median", {
@@ -18,6 +32,20 @@ test_that("function: center.mean and center.median", {
     expect_identical(apply(m, 2, median), colMeans(m))
     m_cmd <- normalize_matrix(m, method = "center.median")
     expect_identical(m_cmn, m_cmd)
+    ## Test HDF5Matrix compatibility
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Data in HDF5
+        tmpf <- paste0(tempdir(), "/mhdf5")
+        mhdf5 <- HDF5Array::writeHDF5Array(m, tmpf, with.dimnames = TRUE)
+        m_cmn_hdf5 <- normalize_matrix(mhdf5, method = "center.mean")
+        expect_true(inherits(m_cmn_hdf5, "HDF5Matrix"))
+        expect_identical(as.matrix(m_cmn_hdf5), m_cmn)
+        m_cmd_hdf5 <- normalize_matrix(mhdf5, method = "center.median")
+        expect_true(inherits(m_cmn_hdf5, "HDF5Matrix"))
+        expect_identical(as.matrix(m_cmd_hdf5), m_cmd)
+        ## Remove file
+        unlink(tmpf)
+    }
 })
 
 test_that("function: div.mean and div.median", {
@@ -26,6 +54,20 @@ test_that("function: div.mean and div.median", {
     m_dmd <- normalize_matrix(m, method = "div.median")
     expect_equal(colMeans(m_dmn), rep(1, 4))
     expect_equal(apply(m_dmd, 2, median), rep(1, 4))
+    ## Test HDF5Matrix compatibility
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Data in HDF5
+        tmpf <- paste0(tempdir(), "/mhdf5")
+        mhdf5 <- HDF5Array::writeHDF5Array(m, tmpf, with.dimnames = TRUE)
+        m_dmn_hdf5 <- normalize_matrix(mhdf5, method = "div.mean")
+        expect_true(inherits(m_dmn_hdf5, "HDF5Matrix"))
+        expect_identical(as.matrix(m_dmn_hdf5), m_dmn)
+        m_dmd_hdf5 <- normalize_matrix(mhdf5, method = "div.median")
+        expect_true(inherits(m_dmd_hdf5, "HDF5Matrix"))
+        expect_identical(as.matrix(m_dmd_hdf5), m_dmd)
+        ## Remove file
+        unlink(tmpf)
+    }
 })
 
 
@@ -34,4 +76,15 @@ test_that("function: diff.median", {
     m_dmed <- normalize_matrix(m, method = "diff.median")
     expect_equal(apply(m_dmed, 2, median),
                  rep(median(m), 4))
+    ## Test HDF5Matrix compatibility
+    if (requireNamespace("HDF5Array", quietly = TRUE)) {
+        ## Data in HDF5
+        tmpf <- paste0(tempdir(), "/mhdf5")
+        mhdf5 <- HDF5Array::writeHDF5Array(m, tmpf, with.dimnames = TRUE)
+        m_dmed_hdf5 <- normalize_matrix(mhdf5, method = "diff.median")
+        expect_true(inherits(m_dmed_hdf5, "HDF5Matrix"))
+        expect_identical(as.matrix(m_dmed_hdf5), m_dmed)
+        ## Remove file
+        unlink(tmpf)
+    }
 })


### PR DESCRIPTION
Hello, 

This PR provides support for matrices stored in HDF5. This is in response to an ongoing issue in `QFeatures`: https://github.com/rformassspectrometry/QFeatures/issues/171

There are several functionality in `MsCoreUtils` that do not allow to provide matrices in an other class than `matrix`. The functionality I currently identified to be adapted (for `QFeatures`) are aggregation, imputation and normalization. 

### Discussion

**please do not merge!** In the current state of the PR, I adapted the code only for aggregation as an example. I would like to discuss several points: 

1. Do you would agree on having HDF5 support for `MsCoreUtils`?
2. If yes, do you agree on the implementation so far?
3. I face one important consideration. Given an `HDF5Matrix` object as input, should we expect an `HDF5Matrix` object as output? For the moment, I convert to `matrix` for convenience so that `aggregate_by_{matrix|vector}()` systematically return a `matrix`. 
4. Later on, I can work on imputation and normalization. Can you think of other steps that should be adapted?

### bonus

I found a little bug in `aggregate_by_matrix()` when missing data is present. I solved the issue and also include an `na.rm` argument as suggested in the example. I can make a separate PR if needed. 
