### PR TITLE
feat: reimplement between in C

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## MsCoreUtils 1.11.2
 
-- Nothing yet.
+- Reimplement `between` in C (see issue #105).
 
 ## MsCoreUtils 1.11.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 ## MsCoreUtils 1.11.2
 
 - Reimplement `between` in C (see issue #105).
+- Use symbols to call registered C methods for faster lookup (see PR #106 and
+  [Writing R extensions: Converting a package to use registration](https://cran.r-project.org/doc/manuals/R-exts.html#Converting-a-package-to-use-registration)).
 
 ## MsCoreUtils 1.11.1
 

--- a/R/imputation.R
+++ b/R/imputation.R
@@ -309,7 +309,7 @@ impute_neighbour_average <- function(x, k = min(x, na.rm = TRUE), MARGIN = 1L) {
     message("Assuming values are ordered.")
     MARGIN <- .checkMargin(MARGIN)
     if (MARGIN == 2L) x <- t(x)
-    res <- .Call("C_impNeighbourAvg", x, k)
+    res <- .Call(C_impNeighbourAvg, x, k)
     if (MARGIN == 2L) return(t(res))
     else return(res)
 }

--- a/R/localMaxima.R
+++ b/R/localMaxima.R
@@ -21,5 +21,5 @@
 localMaxima <- function(x, hws = 1L) {
     i <- seq_along(x) + hws
     side <- rep.int(0L, hws)
-    .Call("C_localMaxima", c(side, x, side), hws)[i]
+    .Call(C_localMaxima, c(side, x, side), hws)[i]
 }

--- a/R/matching.R
+++ b/R/matching.R
@@ -140,19 +140,19 @@ closest <- function(x, table, tolerance = Inf, ppm = 0,
 
     switch(duplicates[1L],
         "keep" = .Call(
-            "C_closest_dup_keep",
+            C_closest_dup_keep,
             as.double(x), as.double(table),
             as.double(tolerance),
             as.integer(nomatch)
         ),
         "closest" = .Call(
-            "C_closest_dup_closest",
+            C_closest_dup_closest,
             as.double(x), as.double(table),
             as.double(tolerance),
             as.integer(nomatch)
         ),
         "remove" = .Call(
-            "C_closest_dup_remove",
+            C_closest_dup_remove,
             as.double(x), as.double(table),
             as.double(tolerance),
             as.integer(nomatch)
@@ -255,10 +255,10 @@ join <- function(x, y, tolerance = 0, ppm = 0,
     tolerance <- tolerance + ppm(x, ppm = ppm) + sqrt(.Machine$double.eps)
 
     switch(type[1L],
-           "outer" = .Call("C_join_outer", x, y, tolerance, NA_integer_),
-           "left" = .Call("C_join_left", x, y, tolerance, NA_integer_),
-           "right" = .Call("C_join_right", x, y, tolerance, NA_integer_),
-           "inner" = .Call("C_join_inner", x, y, tolerance, NA_integer_),
+           "outer" = .Call(C_join_outer, x, y, tolerance, NA_integer_),
+           "left" = .Call(C_join_left, x, y, tolerance, NA_integer_),
+           "right" = .Call(C_join_right, x, y, tolerance, NA_integer_),
+           "inner" = .Call(C_join_inner, x, y, tolerance, NA_integer_),
            stop("'type' has to be one of \"outer\", \"left\", \"right\", or ",
                 "\"inner\"")
     )

--- a/R/range.R
+++ b/R/range.R
@@ -16,7 +16,7 @@
 #' @export
 #' @examples
 #' between(1:4, 2:3)
-between <- function(x, range).Call(C_between, x, as.numeric(range))
+between <- function(x, range).Call(C_between, x, range)
 
 #' @rdname range
 #'

--- a/R/range.R
+++ b/R/range.R
@@ -16,18 +16,7 @@
 #' @export
 #' @examples
 #' between(1:4, 2:3)
-between <- function(x, range) {
-    if (!is.numeric(x))
-        stop("'x' has to be numeric.")
-    if (!is.double(x))
-        x <- as.double(x)
-    if (!is.numeric(range) || length(range) != 2L)
-        stop("'range' has to be a numeric of length 2.")
-    if (range[1L] > range[2L])
-        range[2L:1L] <- range[1L:2L]
-
-    .Call(C_between, x, as.numeric(range[1L]), as.numeric(range[2L]))
-}
+between <- function(x, range).Call(C_between, x, as.numeric(range))
 
 #' @rdname range
 #'

--- a/R/range.R
+++ b/R/range.R
@@ -12,6 +12,7 @@
 #' @return `logical` vector of length `length(x)`.
 #' @aliases between
 #' @family helper functions for developers
+#' @useDynLib MsCoreUtils, .registration = TRUE
 #' @export
 #' @examples
 #' between(1:4, 2:3)
@@ -25,7 +26,7 @@ between <- function(x, range) {
     if (range[1L] > range[2L])
         range[2L:1L] <- range[1L:2L]
 
-    .Call("C_between", x, as.numeric(range[1L]), as.numeric(range[2L]))
+    .Call(C_between, x, as.numeric(range[1L]), as.numeric(range[2L]))
 }
 
 #' @rdname range

--- a/R/range.R
+++ b/R/range.R
@@ -18,11 +18,14 @@
 between <- function(x, range) {
     if (!is.numeric(x))
         stop("'x' has to be numeric.")
+    if (!is.double(x))
+        x <- as.double(x)
     if (!is.numeric(range) || length(range) != 2L)
         stop("'range' has to be a numeric of length 2.")
     if (range[1L] > range[2L])
         range[2L:1L] <- range[1L:2L]
-    range[1L] <= x & x <= range[2L]
+
+    .Call("C_between", x, as.numeric(range[1L]), as.numeric(range[2L]))
 }
 
 #' @rdname range

--- a/R/which.R
+++ b/R/which.R
@@ -19,10 +19,10 @@
 #' @examples
 #' l <- 2 <= 1:3
 #' which.first(l)
-which.first <- function(x).Call("C_which_first", x)
+which.first <- function(x).Call(C_which_first, x)
 
 #' @rdname which
 #' @export
 #' @examples
 #' which.last(l)
-which.last <- function(x).Call("C_which_last", x)
+which.last <- function(x).Call(C_which_last, x)

--- a/src/MsCoreUtils.h
+++ b/src/MsCoreUtils.h
@@ -19,6 +19,7 @@ extern SEXP C_join_outer(SEXP, SEXP, SEXP, SEXP);
 
 extern SEXP C_which_first(SEXP);
 extern SEXP C_which_last(SEXP);
+extern SEXP C_between(SEXP, SEXP, SEXP);
 
 extern SEXP C_localMaxima(SEXP, SEXP);
 

--- a/src/MsCoreUtils.h
+++ b/src/MsCoreUtils.h
@@ -19,7 +19,7 @@ extern SEXP C_join_outer(SEXP, SEXP, SEXP, SEXP);
 
 extern SEXP C_which_first(SEXP);
 extern SEXP C_which_last(SEXP);
-extern SEXP C_between(SEXP, SEXP, SEXP);
+extern SEXP C_between(SEXP, SEXP);
 
 extern SEXP C_localMaxima(SEXP, SEXP);
 

--- a/src/between.c
+++ b/src/between.c
@@ -14,7 +14,10 @@ SEXP C_between(SEXP x, SEXP range) {
     if (!isReal(x))
         x = coerceVector(x, REALSXP);
 
-    if (!isReal(range) || XLENGTH(range) != 2L)
+    if (!isReal(range))
+        range = coerceVector(range, REALSXP);
+
+    if (XLENGTH(range) != 2L)
         error("'range' has to be a numeric of length 2.");
 
     double l = REAL(range)[0], r = REAL(range)[1];

--- a/src/between.c
+++ b/src/between.c
@@ -1,0 +1,33 @@
+#include "MsCoreUtils.h"
+
+#include <R.h>
+#include <Rinternals.h>
+
+/**
+ * Determine whether a vector element is between a given range of values.
+ *
+ * \param x numeric
+ * \param left numeric(1)
+ * \param right numeric(1)
+ * \author Sebastian Gibb
+ */
+SEXP C_between(SEXP x, SEXP left, SEXP right) {
+    double l = REAL(left)[0], r = REAL(right)[0];
+
+    R_xlen_t n = XLENGTH(x);
+    SEXP between = PROTECT(allocVector(LGLSXP, n));
+    int* pbetween = LOGICAL(between);
+
+    if (R_IsNA(l) || R_IsNA(r))
+        for (R_xlen_t i = 0; i < n; ++i, ++pbetween)
+            *pbetween = NA_LOGICAL;
+    else {
+        double* px = REAL(x);
+        for (R_xlen_t i = 0; i < n; ++i, ++pbetween, ++px)
+            *pbetween = R_IsNA(*px) ? NA_LOGICAL : l <= *px && *px <= r;
+    }
+
+    UNPROTECT(1);
+
+    return between;
+}

--- a/src/between.c
+++ b/src/between.c
@@ -7,12 +7,23 @@
  * Determine whether a vector element is between a given range of values.
  *
  * \param x numeric
- * \param left numeric(1)
- * \param right numeric(1)
+ * \param range numeric(2)
  * \author Sebastian Gibb
  */
-SEXP C_between(SEXP x, SEXP left, SEXP right) {
-    double l = REAL(left)[0], r = REAL(right)[0];
+SEXP C_between(SEXP x, SEXP range) {
+    if (!isReal(x))
+        x = coerceVector(x, REALSXP);
+
+    if (!isReal(range) || XLENGTH(range) != 2L)
+        error("'range' has to be a numeric of length 2.");
+
+    double l = REAL(range)[0], r = REAL(range)[1];
+
+    if (l > r) {
+        double tmp = r;
+        r = l;
+        l = tmp;
+    }
 
     R_xlen_t n = XLENGTH(x);
     SEXP between = PROTECT(allocVector(LGLSXP, n));

--- a/src/init.c
+++ b/src/init.c
@@ -12,7 +12,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_localMaxima", (DL_FUNC) &C_localMaxima, 2},
     {"C_which_first", (DL_FUNC) &C_which_first, 1},
     {"C_which_last", (DL_FUNC) &C_which_last, 1},
-    {"C_between", (DL_FUNC) &C_between, 3},
+    {"C_between", (DL_FUNC) &C_between, 2},
     {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -12,6 +12,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_localMaxima", (DL_FUNC) &C_localMaxima, 2},
     {"C_which_first", (DL_FUNC) &C_which_first, 1},
     {"C_which_last", (DL_FUNC) &C_which_last, 1},
+    {"C_between", (DL_FUNC) &C_between, 3},
     {NULL, NULL, 0}
 };
 

--- a/tests/testthat/test_range.R
+++ b/tests/testthat/test_range.R
@@ -1,7 +1,15 @@
 test_that("between throws errors", {
-    expect_error(between("A", 1:2), "numeric")
-    expect_error(between(1, c("A", "B")), "numeric of length 2")
     expect_error(between(1, 1:4), "numeric of length 2")
+})
+
+test_that("between throws warnings", {
+    expect_warning(between("A", 1:2), "NAs introduced")
+    expect_warning(between(1, c("A", "B")), "NAs introduced")
+})
+
+test_that("between handles NA", {
+    expect_equal(suppressWarnings(between("A", 1:2)), NA)
+    expect_equal(suppressWarnings(between(1:3, c("A", "B"))), rep(NA, 3))
 })
 
 test_that("between", {


### PR DESCRIPTION
As discussed in #105 I reimplement `between` in C. Unfortunately it is slower than the R version for `x` of a length below 10000. I quite don't understand why. For comparison I add the current dplyr 1.0.10 (old and fast C implementation which is nearly identical).

Does anybody has an idea why
1. `dplyr` is faster than our `between` while using the identical C implementation?
2. the `inline` function is faster than the "real" compiled one?

``` r
library(microbenchmark)
library(MsCoreUtils)
#> 
#> Attaching package: 'MsCoreUtils'
#> The following object is masked from 'package:stats':
#> 
#>     smooth
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following object is masked from 'package:MsCoreUtils':
#> 
#>     between
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union

library(inline)

.betweenc <- cfunction(c(x = "double", left = "double", right = "double"), "
  double l = REAL(left)[0], r = REAL(right)[0];
  double* px = REAL(x);
  R_xlen_t n = XLENGTH(x);
  SEXP between = PROTECT(allocVector(LGLSXP, n));
  int* pbetween = LOGICAL(between);

  if (R_IsNA(l) || R_IsNA(r))
    for (R_xlen_t i = 0; i < n; ++i, ++pbetween)
      *pbetween = NA_LOGICAL;
  else {
    for (R_xlen_t i = 0; i < n; ++i, ++pbetween, ++px)
      *pbetween = R_IsNA(*px) ? NA_LOGICAL : l <= *px && *px <= r;
  }

  UNPROTECT(1);

  return between;
")

betweenc <- function(x, range) {
    if (!is.numeric(x))
        stop("'x' has to be numeric.")
    if (!is.numeric(range) || length(range) != 2L)
        stop("'range' has to be a numeric of length 2.")
    if (range[1L] > range[2L])
        range[2L:1L] <- range[1L:2L]
    .betweenc(x, range[1L], range[2L])
}

betweenr <- function(x, range) {
    if (!is.numeric(x))
        stop("'x' has to be numeric.")
    if (!is.numeric(range) || length(range) != 2L)
        stop("'range' has to be a numeric of length 2.")
    if (range[1L] > range[2L])
        range[2L:1L] <- range[1L:2L]
    range[1L] <= x & x <= range[2L]
}
set.seed(123)
rt <- rnorm(n = 100, mean = 50)
microbenchmark(
    MsCoreUtils::between(rt, c(50, 51)),
    dplyr::between(rt, 50, 51),
    betweenc(rt, c(50, 51)),
    betweenr(rt, c(50, 51)),
    check = "identical"
)
#> Unit: microseconds
#>                                 expr   min     lq     mean median     uq
#>  MsCoreUtils::between(rt, c(50, 51)) 4.903 5.1290  5.73173 5.3085 5.4880
#>           dplyr::between(rt, 50, 51) 2.050 2.4100  3.07640 2.5795 2.7265
#>              betweenc(rt, c(50, 51)) 2.674 2.8695 83.04341 3.0440 3.1840
#>              betweenr(rt, c(50, 51)) 2.514 2.7895 93.48175 2.9270 3.1000
#>       max neval cld
#>    20.365   100   a
#>    26.080   100   a
#>  7991.593   100   a
#>  9041.177   100   a

rt <- rnorm(n = 10000, mean = 50)
microbenchmark(
    MsCoreUtils::between(rt, c(50, 51)),
    dplyr::between(rt, 50, 51),
    betweenc(rt, c(50, 51)),
    betweenr(rt, c(50, 51)),
    check = "identical"
)
#> Unit: microseconds
#>                                 expr     min       lq      mean  median
#>  MsCoreUtils::between(rt, c(50, 51))  78.298  80.5355  85.57261  82.813
#>           dplyr::between(rt, 50, 51)  86.060  88.7645  93.57228  91.792
#>              betweenc(rt, c(50, 51))  76.612  78.2915  81.61984  80.566
#>              betweenr(rt, c(50, 51)) 107.936 118.4275 124.46958 122.070
#>        uq     max neval  cld
#>   84.3940 199.108   100  b  
#>   92.7275 141.283   100   c 
#>   81.3750 116.498   100 a   
#>  125.4595 166.875   100    d
```

<sup>Created on 2022-12-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>