### PR TITLE
fix: check for y vector order in `bin`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,11 @@ Authors@R: c(person(given = "RforMassSpectrometry Package Maintainer",
                     email = "michael.witting@helmholtz-muenchen.de",
                     role = "ctb",
                     comment = c(ORCID = "0000-0002-1462-4426")),
-             person(given = "Samuel", family = "Wieczorek", role = "ctb"))
+             person(given = "Samuel", family = "Wieczorek", role = "ctb"),
+             person(given = "Roger", family = "Gine Bertomeu", 
+                    email = "roger.gine@iispv.cat",
+                    comment = c(ORCID = "0000-0003-0288-9619"),
+                    role = "ctb"))
 Depends:
     R (>= 3.6.0)
 Imports:

--- a/R/binning.R
+++ b/R/binning.R
@@ -8,9 +8,9 @@
 #'
 #' @param x `numeric` with the values that should be aggregated/binned.
 #'
-#' @param y `numeric` with same length than `x` with values to be used for
-#'     the binning. Ideally, `y` should be increasingly sorted, but it's not 
-#'     mandatory.
+#' @param y `numeric` with same length than `x` with values to be used for the
+#'   binning. `y` **must** be increasingly sorted, or else an error will be
+#'   thrown.
 #'
 #' @param size `numeric(1)` with the size of a bin.
 #'
@@ -24,6 +24,10 @@
 #'     `returnMids = FALSE` might be useful if the breaks are defined before
 #'     hand and binning needs to be performed on a large set of values (i.e.
 #'     within a loop for multiple pairs of `x` and `y` values).
+#'     
+#' @param .check `logical(1)` whether to check that `y` is an ordered vector.
+#'     Setting `.check = FALSE` will improve performance, provided you are sure
+#'     that `y` is always ordered.
 #'
 #' @return
 #'
@@ -57,13 +61,12 @@
 bin <- function(x, y, size = 1,
                 breaks = seq(floor(min(y)),
                              ceiling(max(y)), by = size), FUN = max,
-                returnMids = TRUE) {
+                returnMids = TRUE,
+                .check = TRUE) {
     if (length(x) != length(y))
         stop("lengths of 'x' and 'y' have to match.")
-    if (is.unsorted(y)) {
-        x <- x[order(y)]
-        y <- sort(y)
-    }
+    if (.check) 
+        if (is.unsorted(y)) stop("'y' must be an ordered vector")
     FUN <- match.fun(FUN)
     breaks <- .fix_breaks(breaks, range(y))
     nbrks <- length(breaks)

--- a/R/binning.R
+++ b/R/binning.R
@@ -9,7 +9,8 @@
 #' @param x `numeric` with the values that should be aggregated/binned.
 #'
 #' @param y `numeric` with same length than `x` with values to be used for
-#'     the binning.
+#'     the binning. Ideally, `y` should be increasingly sorted, but it's not 
+#'     mandatory.
 #'
 #' @param size `numeric(1)` with the size of a bin.
 #'
@@ -59,6 +60,10 @@ bin <- function(x, y, size = 1,
                 returnMids = TRUE) {
     if (length(x) != length(y))
         stop("lengths of 'x' and 'y' have to match.")
+    if (is.unsorted(y)) {
+        x <- x[order(y)]
+        y <- sort(y)
+    }
     FUN <- match.fun(FUN)
     breaks <- .fix_breaks(breaks, range(y))
     nbrks <- length(breaks)

--- a/man/binning.Rd
+++ b/man/binning.Rd
@@ -10,15 +10,16 @@ bin(
   size = 1,
   breaks = seq(floor(min(y)), ceiling(max(y)), by = size),
   FUN = max,
-  returnMids = TRUE
+  returnMids = TRUE,
+  .check = TRUE
 )
 }
 \arguments{
 \item{x}{\code{numeric} with the values that should be aggregated/binned.}
 
-\item{y}{\code{numeric} with same length than \code{x} with values to be used for
-the binning. Ideally, \code{y} should be increasingly sorted, but it's not
-mandatory.}
+\item{y}{\code{numeric} with same length than \code{x} with values to be used for the
+binning. \code{y} \strong{must} be increasingly sorted, or else an error will be
+thrown.}
 
 \item{size}{\code{numeric(1)} with the size of a bin.}
 
@@ -32,6 +33,10 @@ returned in addition to the binned (aggregated) values of \code{x}. Setting
 \code{returnMids = FALSE} might be useful if the breaks are defined before
 hand and binning needs to be performed on a large set of values (i.e.
 within a loop for multiple pairs of \code{x} and \code{y} values).}
+
+\item{.check}{\code{logical(1)} whether to check that \code{y} is an ordered vector.
+Setting \code{.check = FALSE} will improve performance, provided you are sure
+that \code{y} is always ordered.}
 }
 \value{
 Depending on the value of \code{returnMids}:

--- a/man/binning.Rd
+++ b/man/binning.Rd
@@ -17,7 +17,8 @@ bin(
 \item{x}{\code{numeric} with the values that should be aggregated/binned.}
 
 \item{y}{\code{numeric} with same length than \code{x} with values to be used for
-the binning.}
+the binning. Ideally, \code{y} should be increasingly sorted, but it's not
+mandatory.}
 
 \item{size}{\code{numeric(1)} with the size of a bin.}
 

--- a/tests/testthat/test_binning.R
+++ b/tests/testthat/test_binning.R
@@ -48,6 +48,16 @@ test_that("bin works", {
     expect_true(is.numeric(res_2))
     expect_equal(res$x, res_2)
 
+    ## Ensure y order does not matter
+    ## Issue #108 https://github.com/rformassspectrometry/MsCoreUtils/issues/108
+    expect_false(is.unsorted(xs))
+    expect_equal(bin(vals, xs), bin(rev(vals), rev(xs)))
+    xs_unsorted <- sample(xs, length(xs))
+    expect_true(is.unsorted(xs_unsorted))
+    expect_equal(bin(vals, xs_unsorted),
+                 bin(vals[order(xs_unsorted)], sort(xs_unsorted)))
+    
+
     ## Check exceptions
     expect_error(bin(1:3, 1:5))
     expect_error(bin(1:3, 1:5), FUN = other)

--- a/tests/testthat/test_binning.R
+++ b/tests/testthat/test_binning.R
@@ -48,13 +48,10 @@ test_that("bin works", {
     expect_true(is.numeric(res_2))
     expect_equal(res$x, res_2)
 
-    ## Ensure y order does not matter
+    ## Ensure y is ordered (if .check = TRUE), throw error if its not
     ## Issue #108 https://github.com/rformassspectrometry/MsCoreUtils/issues/108
-    expect_equal(bin(vals, xs), bin(rev(vals), rev(xs)))
-    xs_unsorted <- sample(xs, length(xs))
-    expect_equal(bin(vals, xs_unsorted),
-                 bin(vals[order(xs_unsorted)], sort(xs_unsorted)))
-    
+    expect_error(bin(1:5, 5:1))
+    expect_no_error(bin(1:5, 5:1, .check = FALSE))
 
     ## Check exceptions
     expect_error(bin(1:3, 1:5))

--- a/tests/testthat/test_binning.R
+++ b/tests/testthat/test_binning.R
@@ -50,10 +50,8 @@ test_that("bin works", {
 
     ## Ensure y order does not matter
     ## Issue #108 https://github.com/rformassspectrometry/MsCoreUtils/issues/108
-    expect_false(is.unsorted(xs))
     expect_equal(bin(vals, xs), bin(rev(vals), rev(xs)))
     xs_unsorted <- sample(xs, length(xs))
-    expect_true(is.unsorted(xs_unsorted))
     expect_equal(bin(vals, xs_unsorted),
                  bin(vals[order(xs_unsorted)], sort(xs_unsorted)))
     


### PR DESCRIPTION
Add a check to `bin` to ensure y is ordered. #108
Update related documentation.
Add unit tests to ensure the fix works.