### PR TITLE
fix: use R_Calloc/R_Free instead of Calloc/Free to reflect changes in R API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MsCoreUtils
 Title: Core Utils for Mass Spectrometry Data
-Version: 1.17.2
+Version: 1.17.3
 Description: MsCoreUtils defines low-level functions for mass
     spectrometry data and is independent of any high-level data
     structures. These functions include mass spectra processing

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # MsCoreUtils 1.17
 
+## MsCoreUtils 1.17.3
+
+- Use `R_Calloc` and `R_Free` instead of `Calloc` and `Free` in
+  `src/lowerConvexHull.c`, respectively, to reflect changes in the R API and
+  fullfil STRICT_R_HEADERS check.
+
 ## MsCoreUtils 1.17.2
 
 - Fix typo in normalisation methods description.

--- a/src/lowerConvexHull.c
+++ b/src/lowerConvexHull.c
@@ -43,7 +43,7 @@ SEXP C_lowerConvexHull(SEXP x, SEXP y) {
   PROTECT(output=allocVector(REALSXP, n));
   /* TODO: replace by R_xlen_t in R 3.0.0 */
   /* allocate vector - error handling is done by R */
-  nodes=(int*) Calloc((size_t) n, int);
+  nodes=(int*) R_Calloc((size_t) n, int);
 
   double* xx=REAL(x);
   double* xy=REAL(y);
@@ -71,7 +71,7 @@ SEXP C_lowerConvexHull(SEXP x, SEXP y) {
 
   xo[n-1]=xy[n-1];
 
-  Free(nodes);
+  R_Free(nodes);
   UNPROTECT(3);
 
   return(output);


### PR DESCRIPTION
Use `R_Calloc` and `R_Free` instead of `Calloc` and `Free` in  `src/lowerConvexHull.c`, respectively, to reflect changes in the R API and fullfil `STRICT_R_HEADERS` check.