### PR TITLE
refactor: add parameters warningsAsErrors and verbose to retry()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MsCoreUtils
 Title: Core Utils for Mass Spectrometry Data
-Version: 1.23.7
+Version: 1.23.8
 Description: MsCoreUtils defines low-level functions for mass
     spectrometry data and is independent of any high-level data
     structures. These functions include mass spectra processing

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # MsCoreUtils 1.23
 
+## MsCoreUtils 1.23.8
+
+- Add parameters `warningsAsErrors` and `verbose` to `retry()`.
+
 ## MsCoreUtils 1.23.7
 
 - Add `retry()` function.

--- a/R/retry.R
+++ b/R/retry.R
@@ -20,6 +20,12 @@
 #'     such as temporary internet connection problems. The pattern defined by
 #'     `retry_on` is directly passed to the `grepl()` function.
 #'
+#' @param warningsAsErrors `logical(1)` whether warnings should be converted
+#'     to errors. Defaults to `warningsAsErrors = FALSE`.
+#'
+#' @param verbose `logical(1)` whether additional messages on eventually caught
+#'     errors should be printed. Defaults to `verbose = FALSE`.
+#'
 #' @param ... optional parameters passed to `grepl()`.
 #'
 #' @note
@@ -44,13 +50,24 @@
 #'                  retry_on = "temporarily", ntimes = 7L, sleep_mult = 10)
 #' }
 retry <- function(expr, ntimes = 5L, sleep_mult = 0L,
-                  retry_on = "*", ...) {
+                  retry_on = "*", warningsAsErrors = FALSE,
+                  verbose = FALSE,...) {
     res <- NULL
+    if (warningsAsErrors) {
+        w <- getOption("warn")
+        options(warn = 2)
+        on.exit(options(warn = w))
+    }
     for (i in seq_len(ntimes)) {
-        res <- suppressWarnings(tryCatch(expr, error = function(e) e))
+        ## the `eval.parent` comes from https://stackoverflow.com/questions/20596902/r-avoiding-restarting-interrupted-promise-evaluation-warning
+        res <- tryCatch(eval.parent(substitute(expr)), error = function(e) e)
         if (is(res, "simpleError")) {
-            if (grepl(retry_on, res$message, ...) && i < ntimes)
+            if (grepl(retry_on, res$message, ...) && i < ntimes) {
+                if (verbose)
+                    message("Caught error: ", res$message, ". Will retry in ",
+                            i * sleep_mult, " seconds")
                 Sys.sleep(i * sleep_mult)
+            }
             else stop(res)
         } else break
     }

--- a/man/retry.Rd
+++ b/man/retry.Rd
@@ -4,7 +4,15 @@
 \alias{retry}
 \title{Retry expression on failure}
 \usage{
-retry(expr, ntimes = 5L, sleep_mult = 0L, retry_on = "*", ...)
+retry(
+  expr,
+  ntimes = 5L,
+  sleep_mult = 0L,
+  retry_on = "*",
+  warningsAsErrors = FALSE,
+  verbose = FALSE,
+  ...
+)
 }
 \arguments{
 \item{expr}{Expression to be evaluated.}
@@ -19,6 +27,12 @@ Defaults to \code{retry_on = "*"} hence retrying \code{expr} on any error that
 occurs. This allows to restrict retrying \code{expr} for specific cases,
 such as temporary internet connection problems. The pattern defined by
 \code{retry_on} is directly passed to the \code{grepl()} function.}
+
+\item{warningsAsErrors}{\code{logical(1)} whether warnings should be converted
+to errors. Defaults to \code{warningsAsErrors = FALSE}.}
+
+\item{verbose}{\code{logical(1)} whether additional messages on eventually caught
+errors should be printed. Defaults to \code{verbose = FALSE}.}
 
 \item{...}{optional parameters passed to \code{grepl()}.}
 }

--- a/tests/testthat/test_retry.R
+++ b/tests/testthat/test_retry.R
@@ -37,13 +37,13 @@ test_that("retry works", {
     ## connection errors.
     expect_warning(expect_error(
         retry(readLines("https://www.goog.el"), verbose = TRUE), "cannot"),
-        "connect to server")
+        "Could")
     expect_warning(expect_error(
         retry(readLines("https://www.goog.el"), verbose = TRUE,
               retry_on = "connect to"), "cannot"),
-        "connect to server")
+        "Could")
     expect_error(
         retry(readLines("https://www.goog.el"), verbose = TRUE,
-              warningsAsErrors = TRUE, retry_on = "connect to"),
-        "connect to server")
+              warningsAsErrors = TRUE, retry_on = "Could"),
+        "Could")
 })

--- a/tests/testthat/test_retry.R
+++ b/tests/testthat/test_retry.R
@@ -6,12 +6,44 @@ test_that("retry works", {
     }
     set.seed(123)
     ## With a seed of 123 `a()` throws an error 3 times and works on the 4th
-    res <- retry(a(), ntimes = 5L)
+    res <- retry(a(), ntimes = 5L, verbose = TRUE)
     expect_equal(res, 1)
     ## Failure (fails 3 consecutive times)
     set.seed(123)
-    expect_error(retry(a(), ntimes = 3L), "A, got a 0")
+    expect_error(retry(a(), ntimes = 3L, verbose = TRUE), "A, got a 0")
 
     ## Always fails
-    expect_error(retry(hello, ntimes = 5L, retry_on = "not found"), "not found")
+    expect_error(retry(hello, ntimes = 5L, retry_on = "not found",
+                       verbose = TRUE), "not found")
+
+    ## warnings as errors
+    my_fun <- function(x) {
+        warning("hello there")
+        x * x
+    }
+    expect_warning(res <- retry(my_fun(3), ntimes = 5L, verbose = TRUE),
+                   "hello there")
+    expect_equal(res, 9)
+    w <- getOption("warn")
+    expect_error(retry(my_fun(3), ntimes = 5L, verbose = TRUE,
+                       warningsAsErrors = TRUE), "hello there")
+    expect_equal(getOption("warn"), w)
+
+
+    expect_error(retry(my_fun(3), ntimes = 5L, verbose = TRUE,
+                       retry_on = "hello",
+                       warningsAsErrors = TRUE), "hello")
+
+    ## connection errors.
+    expect_warning(expect_error(
+        retry(readLines("https://www.goog.el"), verbose = TRUE), "cannot"),
+        "connect to server")
+    expect_warning(expect_error(
+        retry(readLines("https://www.goog.el"), verbose = TRUE,
+              retry_on = "connect to"), "cannot"),
+        "connect to server")
+    expect_error(
+        retry(readLines("https://www.goog.el"), verbose = TRUE,
+              warningsAsErrors = TRUE, retry_on = "connect to"),
+        "connect to server")
 })


### PR DESCRIPTION
This PR adds two new parameters to `retry()`:
- `warningsAsErrors` to convert warnings to errors - this is particularly important when downloading files with *BiocFileCache* as the original error message if a download fails is converted to a warning.
- `verbose` to print whether or not an error was caught and the `expr` is re-evaluated.